### PR TITLE
Fix Mac Catalyst build: duplicate OAuth provider declaration

### DIFF
--- a/Sources/HuggingFace/OAuth/HuggingFaceAuthenticationManager.swift
+++ b/Sources/HuggingFace/OAuth/HuggingFaceAuthenticationManager.swift
@@ -432,7 +432,7 @@ import Foundation
 
 // MARK: -
 
-#if canImport(AppKit) && canImport(AuthenticationServices)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst) && canImport(AuthenticationServices)
     import AppKit
 
     @MainActor
@@ -448,7 +448,7 @@ import Foundation
             NSApp.keyWindow ?? NSApp.windows.first ?? ASPresentationAnchor()
         }
     }
-#endif  // canImport(AppKit) && canImport(AuthenticationServices)
+#endif  // canImport(AppKit) && !targetEnvironment(macCatalyst) && canImport(AuthenticationServices)
 
 #if canImport(UIKit) && canImport(AuthenticationServices)
     import UIKit


### PR DESCRIPTION
## Summary

- On Mac Catalyst, both `canImport(AppKit)` and `canImport(UIKit)` evaluate to true, causing two declarations of `HuggingFaceAuthenticationPresentationContextProvider` to compile simultaneously
- Added `!targetEnvironment(macCatalyst)` to the AppKit `#if` guard so only the UIKit branch compiles under Mac Catalyst

## Errors fixed

- `'HuggingFaceAuthenticationPresentationContextProvider' is ambiguous for type lookup`
- `Invalid redeclaration of 'HuggingFaceAuthenticationPresentationContextProvider'`
- `Cannot convert return expression of type 'NSObject?' to return type 'ASPresentationAnchor'`

## Test plan

- [x] Build for Mac Catalyst destination — no duplicate declaration errors
- [x] iOS build unaffected
- [x] Native macOS build unaffected (only the Catalyst code path changes)