### PR TITLE
Conditionalize `swift-xet` dependency behind `"Xet"` trait

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test-macos:
-    name: Swift ${{ matrix.swift }} on macOS ${{ matrix.macos }} with Xcode ${{ matrix.xcode }}
+    name: Swift ${{ matrix.swift }} on macOS ${{ matrix.macos }} with Xcode ${{ matrix.xcode }}${{ matrix.traits != '' && format(' and --traits {0}', matrix.traits) || '' }}
     runs-on: macos-${{ matrix.macos }}
     env:
       DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer"
@@ -19,12 +19,23 @@ jobs:
           - swift: "6.0"
             xcode: "16.0"
             macos: "15"
+            traits: ""
           - swift: "6.1"
             xcode: "16.3"
             macos: "15"
+            traits: ""
+          - swift: "6.1"
+            xcode: "16.3"
+            macos: "15"
+            traits: "Xet"
           - swift: "6.2"
             xcode: "26.0"
             macos: "26"
+            traits: ""
+          - swift: "6.2"
+            xcode: "26.0"
+            macos: "26"
+            traits: "Xet"
     timeout-minutes: 10
     steps:
       - name: Checkout code
@@ -36,34 +47,41 @@ jobs:
           path: |
             ~/.cache/org.swift.swiftpm
             .build
-          key: ${{ runner.os }}-swift-${{ matrix.swift }}-spm-${{ hashFiles('**/Package.resolved') }}
+          key: ${{ runner.os }}-swift-${{ matrix.swift }}-${{ matrix.traits == '' && 'xet-off' || 'xet-on' }}-spm-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-swift-${{ matrix.swift }}-spm-
+            ${{ runner.os }}-swift-${{ matrix.swift }}-${{ matrix.traits == '' && 'xet-off' || 'xet-on' }}-spm-
 
       - name: Build
-        run: swift build
+        run: swift build${{ matrix.traits != '' && format(' --traits {0}', matrix.traits) || '' }}
 
       - name: Test
-        run: swift test
+        run: swift test${{ matrix.traits != '' && format(' --traits {0}', matrix.traits) || '' }}
 
   test-linux:
-    name: Swift ${{ matrix.swift-version }} on Linux
+    name: Swift ${{ matrix.swift }} on Linux${{ matrix.traits != '' && format(' and --traits {0}', matrix.traits) || '' }}
     runs-on: ubuntu-latest
-    container: "swift:${{ matrix.swift-version }}"
+    container: "swift:${{ matrix.swift }}"
     strategy:
       fail-fast: false
       matrix:
-        swift-version:
-          - "6.0.3"
-          - "6.1.3"
-          - "6.2.3"
+        include:
+          - swift: "6.0.3"
+            traits: ""
+          - swift: "6.1.3"
+            traits: ""
+          - swift: "6.1.3"
+            traits: "Xet"
+          - swift: "6.2.3"
+            traits: ""
+          - swift: "6.2.3"
+            traits: "Xet"
     timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
       - name: Build
-        run: swift build
+        run: swift build${{ matrix.traits != '' && format(' --traits {0}', matrix.traits) || '' }}
 
       - name: Test
-        run: swift test
+        run: swift test${{ matrix.traits != '' && format(' --traits {0}', matrix.traits) || '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,10 @@ jobs:
       - name: Cache Swift Package Manager dependencies
         uses: actions/cache@v5
         with:
-          path: |
-            ~/.cache/org.swift.swiftpm
-            .build
-          key: ${{ runner.os }}-swift-${{ matrix.swift }}-${{ matrix.traits == '' && 'xet-off' || 'xet-on' }}-spm-${{ hashFiles('**/Package.resolved') }}
+          path: ~/.cache/org.swift.swiftpm
+          key: ${{ runner.os }}-xcode-${{ matrix.xcode }}-swift-${{ matrix.swift }}-${{ matrix.traits == '' && 'xet-off' || 'xet-on' }}-spm-${{ hashFiles('Package.swift', 'Package@swift-6.0.swift', '**/Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-swift-${{ matrix.swift }}-${{ matrix.traits == '' && 'xet-off' || 'xet-on' }}-spm-
+            ${{ runner.os }}-xcode-${{ matrix.xcode }}-swift-${{ matrix.swift }}-${{ matrix.traits == '' && 'xet-off' || 'xet-on' }}-spm-
 
       - name: Build
         run: swift build${{ matrix.traits != '' && format(' --traits {0}', matrix.traits) || '' }}

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "881f8351c4d3cfab3a07904c66d12d422608c6e0130fefab52f34b2616292b49",
+  "originHash" : "543b793a4fedd6358f23c7191ff28174ffdb3396391f76f608bfa061bafd2e2b",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattt/EventSource.git",
       "state" : {
-        "revision" : "ca2a9d90cbe49e09b92f4b6ebd922c03ebea51d0",
-        "version" : "1.3.0"
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-distributed-tracing.git",
       "state" : {
-        "revision" : "e109d8b5308d0e05201d9a1dd1c475446a946a11",
-        "version" : "1.4.0"
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "e932d3c4d8f77433c8f7093b5ebcbf91463948a0",
-        "version" : "2.95.0"
+        "revision" : "b31565862a8f39866af50bc6676160d8dda7de35",
+        "version" : "2.96.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -45,11 +45,17 @@ let package = Package(
         ),
         .testTarget(
             name: "HuggingFaceTests",
-            dependencies: ["HuggingFace"]
+            dependencies: ["HuggingFace"],
+            swiftSettings: [
+                .define("HUGGINGFACE_ENABLE_XET", .when(traits: ["Xet"]))
+            ]
         ),
         .testTarget(
             name: "HubBenchmarks",
-            dependencies: ["HuggingFace"]
+            dependencies: ["HuggingFace"],
+            swiftSettings: [
+                .define("HUGGINGFACE_ENABLE_XET", .when(traits: ["Xet"]))
+            ]
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -19,6 +19,13 @@ let package = Package(
             targets: ["HuggingFace"]
         )
     ],
+    traits: [
+        .default(enabledTraits: ["Xet"]),
+        .trait(
+            name: "Xet",
+            description: "Enable Xet transport support.",
+        ),
+    ],
     dependencies: [
         .package(url: "https://github.com/mattt/EventSource.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "5.0.0"),
@@ -30,9 +37,12 @@ let package = Package(
             dependencies: [
                 .product(name: "EventSource", package: "EventSource"),
                 .product(name: "Crypto", package: "swift-crypto"),
-                .product(name: "Xet", package: "swift-xet"),
+                .product(name: "Xet", package: "swift-xet", condition: .when(traits: ["Xet"])),
             ],
-            path: "Sources/HuggingFace"
+            path: "Sources/HuggingFace",
+            swiftSettings: [
+                .define("HUGGINGFACE_ENABLE_XET", .when(traits: ["Xet"]))
+            ]
         ),
         .testTarget(
             name: "HuggingFaceTests",

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -19,12 +19,6 @@ let package = Package(
             targets: ["HuggingFace"]
         )
     ],
-    traits: [
-        .trait(
-            name: "Xet",
-            description: "Enable Xet transport support.",
-        )
-    ],
     dependencies: [
         .package(url: "https://github.com/mattt/EventSource.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "5.0.0"),
@@ -36,11 +30,11 @@ let package = Package(
             dependencies: [
                 .product(name: "EventSource", package: "EventSource"),
                 .product(name: "Crypto", package: "swift-crypto"),
-                .product(name: "Xet", package: "swift-xet", condition: .when(traits: ["Xet"])),
+                .product(name: "Xet", package: "swift-xet"),
             ],
             path: "Sources/HuggingFace",
             swiftSettings: [
-                .define("HUGGINGFACE_ENABLE_XET", .when(traits: ["Xet"]))
+                .define("HUGGINGFACE_ENABLE_XET")
             ]
         ),
         .testTarget(

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -39,11 +39,17 @@ let package = Package(
         ),
         .testTarget(
             name: "HuggingFaceTests",
-            dependencies: ["HuggingFace"]
+            dependencies: ["HuggingFace"],
+            swiftSettings: [
+                .define("HUGGINGFACE_ENABLE_XET")
+            ]
         ),
         .testTarget(
             name: "HubBenchmarks",
-            dependencies: ["HuggingFace"]
+            dependencies: ["HuggingFace"],
+            swiftSettings: [
+                .define("HUGGINGFACE_ENABLE_XET")
+            ]
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -23,6 +23,31 @@ dependencies: [
 ]
 ```
 
+### Optional Xet trait
+
+`swift-huggingface` includes an `Xet` package trait.
+On Swift 6.1+, it is opt-in.
+On Swift 6.0, package traits are unavailable, so Xet remains enabled via the compatibility manifest.
+
+Enable it from the command line when you want Xet support:
+
+```bash
+swift build --traits Xet
+swift test --traits Xet
+```
+
+When declaring `swift-huggingface` as a dependency, enable it explicitly:
+
+```swift
+dependencies: [
+    .package(
+        url: "https://github.com/huggingface/swift-huggingface.git",
+        from: "0.8.0",
+        traits: ["Xet"]
+    )
+]
+```
+
 ## Usage
 
 ### Authentication

--- a/Sources/HuggingFace/Hub/HubClient+Files.swift
+++ b/Sources/HuggingFace/Hub/HubClient+Files.swift
@@ -347,23 +347,31 @@ public extension HubClient {
             return try Data(contentsOf: cachedPath)
         }
 
-        if endpoint == .resolve, transport.shouldAttemptXet {
-            do {
-                if let data = try await downloadDataWithXet(
-                    repoPath: repoPath,
-                    repo: repo,
-                    kind: kind,
-                    revision: revision,
-                    transport: transport
-                ) {
-                    return data
-                }
-            } catch {
-                if transport == .xet {
-                    throw error
+        #if !HUGGINGFACE_ENABLE_XET
+            if transport == .xet {
+                throw HTTPClientError.unexpectedError("Xet transport requires the Xet trait")
+            }
+        #endif
+
+        #if HUGGINGFACE_ENABLE_XET
+            if endpoint == .resolve, transport.shouldAttemptXet {
+                do {
+                    if let data = try await downloadDataWithXet(
+                        repoPath: repoPath,
+                        repo: repo,
+                        kind: kind,
+                        revision: revision,
+                        transport: transport
+                    ) {
+                        return data
+                    }
+                } catch {
+                    if transport == .xet {
+                        throw error
+                    }
                 }
             }
-        }
+        #endif
 
         // Fallback to existing LFS download method
         let url = httpClient.host
@@ -453,26 +461,34 @@ public extension HubClient {
             throw HubCacheError.cachedPathResolutionFailed(repoPath)
         }
 
+        #if !HUGGINGFACE_ENABLE_XET
+            if transport == .xet {
+                throw HTTPClientError.unexpectedError("Xet transport requires the Xet trait")
+            }
+        #endif
+
         // Try Xet transport first when requested and destination is explicit
-        if endpoint == .resolve, transport.shouldAttemptXet, let xetDestination = destination {
-            do {
-                if let downloaded = try await downloadFileWithXet(
-                    repoPath: repoPath,
-                    repo: repo,
-                    kind: kind,
-                    revision: revision,
-                    destination: xetDestination,
-                    progress: progress,
-                    transport: transport
-                ) {
-                    return downloaded
-                }
-            } catch {
-                if transport == .xet {
-                    throw error
+        #if HUGGINGFACE_ENABLE_XET
+            if endpoint == .resolve, transport.shouldAttemptXet, let xetDestination = destination {
+                do {
+                    if let downloaded = try await downloadFileWithXet(
+                        repoPath: repoPath,
+                        repo: repo,
+                        kind: kind,
+                        revision: revision,
+                        destination: xetDestination,
+                        progress: progress,
+                        transport: transport
+                    ) {
+                        return downloaded
+                    }
+                } catch {
+                    if transport == .xet {
+                        throw error
+                    }
                 }
             }
-        }
+        #endif
 
         // Build URL and gather optional preflight metadata for cache-aware flows
         let url = httpClient.host
@@ -1421,11 +1437,15 @@ private extension HubClient {
     }
 
     func snapshotTransport(for entry: Git.TreeEntry) -> FileDownloadTransport {
+        #if HUGGINGFACE_ENABLE_XET
         let useXet = FileDownloadTransport.automatic.shouldUseXet(
             fileSizeBytes: entry.size,
             minimumFileSizeBytes: xetMinimumFileSizeBytes
         )
         return useXet ? .automatic : .lfs
+        #else
+        return .lfs
+        #endif
     }
 
     func makeSnapshotProgressSamplingTask(
@@ -1781,6 +1801,7 @@ private extension HubClient {
                 try await downloader.data(for: fileID)
             }
         #else
+            _ = transport
             return nil
         #endif
     }
@@ -1820,6 +1841,7 @@ private extension HubClient {
 
             return destination
         #else
+            _ = transport
             return nil
         #endif
     }

--- a/Sources/HuggingFace/Hub/HubClient+Files.swift
+++ b/Sources/HuggingFace/Hub/HubClient+Files.swift
@@ -349,7 +349,9 @@ public extension HubClient {
 
         #if !HUGGINGFACE_ENABLE_XET
             if transport == .xet {
-                throw HTTPClientError.unexpectedError("Xet transport requires the Xet trait")
+                throw HTTPClientError.requestError(
+                    "Xet transport requires enabling the Xet package trait"
+                )
             }
         #endif
 
@@ -463,7 +465,9 @@ public extension HubClient {
 
         #if !HUGGINGFACE_ENABLE_XET
             if transport == .xet {
-                throw HTTPClientError.unexpectedError("Xet transport requires the Xet trait")
+                throw HTTPClientError.requestError(
+                    "Xet transport requires enabling the Xet package trait"
+                )
             }
         #endif
 

--- a/Sources/HuggingFace/Hub/HubClient+Files.swift
+++ b/Sources/HuggingFace/Hub/HubClient+Files.swift
@@ -9,7 +9,9 @@ import Foundation
     import FoundationNetworking
 #endif
 
-import Xet
+#if HUGGINGFACE_ENABLE_XET
+    import Xet
+#endif
 
 private let xetMinimumFileSizeBytes = 16 * 1024 * 1024  // 16MiB
 private let snapshotUnknownFileWeight: Int64 = 1
@@ -1760,23 +1762,27 @@ private extension HubClient {
         revision: String,
         transport: FileDownloadTransport
     ) async throws -> Data? {
-        guard
-            let fileID = try await fetchXetFileID(
-                repoPath: repoPath,
-                repo: repo,
-                revision: revision,
-                transport: transport
-            )
-        else {
-            return nil
-        }
+        #if HUGGINGFACE_ENABLE_XET
+            guard
+                let fileID = try await fetchXetFileID(
+                    repoPath: repoPath,
+                    repo: repo,
+                    revision: revision,
+                    transport: transport
+                )
+            else {
+                return nil
+            }
 
-        return try await Xet.withDownloader(
-            refreshURL: xetRefreshURL(for: repo, kind: kind, revision: revision),
-            hubToken: try? await httpClient.tokenProvider.getToken()
-        ) { downloader in
-            try await downloader.data(for: fileID)
-        }
+            return try await Xet.withDownloader(
+                refreshURL: xetRefreshURL(for: repo, kind: kind, revision: revision),
+                hubToken: try? await httpClient.tokenProvider.getToken()
+            ) { downloader in
+                try await downloader.data(for: fileID)
+            }
+        #else
+            return nil
+        #endif
     }
 
     /// Downloads a file using Xet's content-addressable storage system.
@@ -1790,28 +1796,32 @@ private extension HubClient {
         progress: Progress?,
         transport: FileDownloadTransport
     ) async throws -> URL? {
-        guard
-            let fileID = try await fetchXetFileID(
-                repoPath: repoPath,
-                repo: repo,
-                revision: revision,
-                transport: transport
-            )
-        else {
+        #if HUGGINGFACE_ENABLE_XET
+            guard
+                let fileID = try await fetchXetFileID(
+                    repoPath: repoPath,
+                    repo: repo,
+                    revision: revision,
+                    transport: transport
+                )
+            else {
+                return nil
+            }
+
+            _ = try await Xet.withDownloader(
+                refreshURL: xetRefreshURL(for: repo, kind: kind, revision: revision),
+                hubToken: try? await httpClient.tokenProvider.getToken()
+            ) { downloader in
+                try await downloader.download(fileID, to: destination)
+            }
+
+            progress?.totalUnitCount = 100
+            progress?.completedUnitCount = 100
+
+            return destination
+        #else
             return nil
-        }
-
-        _ = try await Xet.withDownloader(
-            refreshURL: xetRefreshURL(for: repo, kind: kind, revision: revision),
-            hubToken: try? await httpClient.tokenProvider.getToken()
-        ) { downloader in
-            try await downloader.download(fileID, to: destination)
-        }
-
-        progress?.totalUnitCount = 100
-        progress?.completedUnitCount = 100
-
-        return destination
+        #endif
     }
 
     /// Fetch the Xet file ID for a given repository, path, and revision.

--- a/Tests/HuggingFaceTests/HubTests/FileOperationsTests.swift
+++ b/Tests/HuggingFaceTests/HubTests/FileOperationsTests.swift
@@ -458,6 +458,65 @@ import Testing
             _ = try await client.downloadContentsOfFile(at: "test.txt", from: repoID, endpoint: .raw)
         }
 
+        #if !HUGGINGFACE_ENABLE_XET
+            @Test("Force Xet download throws when Xet trait is disabled", .mockURLSession)
+            func testForcedXetDownloadThrowsWhenTraitDisabled() async throws {
+                let requestCounter = ProgressCallCounter()
+                await MockURLProtocol.setHandler { _ in
+                    requestCounter.increment()
+                    let response = HTTPURLResponse(
+                        url: URL(string: "https://huggingface.co/user/model/resolve/main/test.txt")!,
+                        statusCode: 500,
+                        httpVersion: "HTTP/1.1",
+                        headerFields: [:]
+                    )!
+                    return (response, Data())
+                }
+
+                let client = createMockClient()
+                let repoID: Repo.ID = "user/model"
+                await #expect(throws: HTTPClientError.self) {
+                    _ = try await client.downloadContentsOfFile(
+                        at: "test.txt",
+                        from: repoID,
+                        transport: .xet
+                    )
+                }
+                #expect(requestCounter.count == 0)
+            }
+
+            @Test("Force Xet file download throws when Xet trait is disabled", .mockURLSession)
+            func testForcedXetFileDownloadThrowsWhenTraitDisabled() async throws {
+                let requestCounter = ProgressCallCounter()
+                await MockURLProtocol.setHandler { _ in
+                    requestCounter.increment()
+                    let response = HTTPURLResponse(
+                        url: URL(string: "https://huggingface.co/user/model/resolve/main/test.txt")!,
+                        statusCode: 500,
+                        httpVersion: "HTTP/1.1",
+                        headerFields: [:]
+                    )!
+                    return (response, Data())
+                }
+
+                let client = createMockClient()
+                let repoID: Repo.ID = "user/model"
+                let destination = FileManager.default.temporaryDirectory
+                    .appendingPathComponent(UUID().uuidString)
+                defer { try? FileManager.default.removeItem(at: destination) }
+
+                await #expect(throws: HTTPClientError.self) {
+                    _ = try await client.downloadFile(
+                        at: "test.txt",
+                        from: repoID,
+                        to: destination,
+                        transport: .xet
+                    )
+                }
+                #expect(requestCounter.count == 0)
+            }
+        #endif
+
         @Test("downloadFile localFilesOnly returns cached file without network", .mockURLSession)
         func testDownloadFileLocalFilesOnlyUsesCache() async throws {
             let commit = "1234567890123456789012345678901234567890"
@@ -1413,9 +1472,11 @@ import Testing
             #expect(starts.contains("small-b.bin"))
             #expect(starts.contains("huge.bin"))
             let hugeStartIndex = starts.firstIndex(of: "huge.bin")!
-            let firstTwo = Set(starts.prefix(2))
-            #expect(firstTwo == Set(["small-a.bin", "small-b.bin"]))
-            #expect(hugeStartIndex >= 2)
+            #if HUGGINGFACE_ENABLE_XET
+                let firstTwo = Set(starts.prefix(2))
+                #expect(firstTwo == Set(["small-a.bin", "small-b.bin"]))
+                #expect(hugeStartIndex >= 2)
+            #endif
         }
 
         @Test("downloadSnapshot progress is size weighted", .mockURLSession)


### PR DESCRIPTION
[swift-xet](https://github.com/huggingface/swift-xet) depends on [async-http-client](https://github.com/swift-server/async-http-client) for fast, parallel downloads. Unfortunately, `AsyncHTTPClient` has a bunch of transitive dependences, which some package consumers find unacceptable:

<img width="350" height="683" alt="Screenshot 2026-03-16 at 02 35 03" src="https://github.com/user-attachments/assets/34dc47cb-56e1-4961-8cb1-29a576b52ff0" />

This PR gates all of these behind a new `"Xet"` trait. As much as I'd like to enable that by default, the ergonomics for disabling package traits in Swift / Xcode aren't great. So here we are.