### PR TITLE
Fix Apple download progress reporting

### DIFF
--- a/Sources/HuggingFace/Hub/HubClient+Files.swift
+++ b/Sources/HuggingFace/Hub/HubClient+Files.swift
@@ -597,11 +597,10 @@ public extension HubClient {
                         #if canImport(FoundationNetworking)
                             (tempURL, response) = try await session.asyncDownload(for: request, progress: progress)
                         #else
-                            (tempURL, response) = try await session.download(
+                            (tempURL, response) = try await session.hfAsyncDownload(
                                 for: request,
-                                delegate: progress.map {
-                                    DownloadProgressDelegate(progress: $0, resumeOffset: resumeOffset)
-                                }
+                                progress: progress,
+                                resumeOffset: resumeOffset
                             )
                         #endif
                     } catch {
@@ -737,9 +736,10 @@ public extension HubClient {
             #if canImport(FoundationNetworking)
                 (tempURL, response) = try await session.asyncDownload(for: baseRequest, progress: progress)
             #else
-                (tempURL, response) = try await session.download(
+                (tempURL, response) = try await session.hfAsyncDownload(
                     for: baseRequest,
-                    delegate: progress.map { DownloadProgressDelegate(progress: $0, resumeOffset: resumeOffset) }
+                    progress: progress,
+                    resumeOffset: resumeOffset
                 )
             #endif
         } catch {
@@ -887,9 +887,9 @@ public extension HubClient {
             to destination: URL,
             progress: Progress? = nil
         ) async throws -> URL {
-            let (tempURL, response) = try await session.download(
+            let (tempURL, response) = try await session.hfAsyncDownload(
                 resumeFrom: resumeData,
-                delegate: progress.map { DownloadProgressDelegate(progress: $0) }
+                progress: progress
             )
             _ = try httpClient.validateResponse(response, data: nil)
 
@@ -940,13 +940,85 @@ public extension HubClient {
 // MARK: - Progress Delegate
 
 #if !canImport(FoundationNetworking)
+    private final class DownloadTaskBox: @unchecked Sendable {
+        var task: URLSessionDownloadTask?
+    }
+
+    private extension URLSession {
+        func hfAsyncDownload(
+            for request: URLRequest,
+            progress: Progress? = nil,
+            resumeOffset: Int64 = 0
+        ) async throws -> (URL, URLResponse) {
+            let box = DownloadTaskBox()
+            return try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { continuation in
+                    let delegate = DownloadProgressDelegate(
+                        progress: progress ?? Progress(totalUnitCount: 0),
+                        resumeOffset: resumeOffset,
+                        continuation: continuation
+                    )
+                    let session = URLSession(
+                        configuration: configuration,
+                        delegate: delegate,
+                        delegateQueue: nil
+                    )
+                    delegate.session = session
+                    let task = session.downloadTask(with: request)
+                    box.task = task
+                    task.resume()
+                }
+            } onCancel: {
+                box.task?.cancel()
+            }
+        }
+
+        func hfAsyncDownload(
+            resumeFrom resumeData: Data,
+            progress: Progress? = nil
+        ) async throws -> (URL, URLResponse) {
+            let box = DownloadTaskBox()
+            return try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { continuation in
+                    let delegate = DownloadProgressDelegate(
+                        progress: progress ?? Progress(totalUnitCount: 0),
+                        appliesResumeOffsetToAllResponses: true,
+                        continuation: continuation
+                    )
+                    let session = URLSession(
+                        configuration: configuration,
+                        delegate: delegate,
+                        delegateQueue: nil
+                    )
+                    delegate.session = session
+                    let task = session.downloadTask(withResumeData: resumeData)
+                    box.task = task
+                    task.resume()
+                }
+            } onCancel: {
+                box.task?.cancel()
+            }
+        }
+    }
+
     private final class DownloadProgressDelegate: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
         private let progress: Progress
-        private let resumeOffset: Int64
+        private let appliesResumeOffsetToAllResponses: Bool
+        private let continuation: CheckedContinuation<(URL, URLResponse), Error>?
+        fileprivate weak var session: URLSession?
+        private var currentResumeOffset: Int64
+        private var hasResumed = false
 
-        init(progress: Progress, resumeOffset: Int64 = 0) {
+        init(
+            progress: Progress,
+            resumeOffset: Int64 = 0,
+            appliesResumeOffsetToAllResponses: Bool = false,
+            continuation: CheckedContinuation<(URL, URLResponse), Error>? = nil
+        ) {
             self.progress = progress
-            self.resumeOffset = resumeOffset
+            self.currentResumeOffset = resumeOffset
+            self.appliesResumeOffsetToAllResponses = appliesResumeOffsetToAllResponses
+            self.continuation = continuation
         }
 
         func urlSession(
@@ -957,7 +1029,10 @@ public extension HubClient {
             totalBytesExpectedToWrite: Int64
         ) {
             let responseStatus = (downloadTask.response as? HTTPURLResponse)?.statusCode
-            let appliedOffset = responseStatus == 206 ? resumeOffset : 0
+            let appliesOffset =
+                currentResumeOffset > 0
+                && (responseStatus == 206 || appliesResumeOffsetToAllResponses)
+            let appliedOffset = appliesOffset ? currentResumeOffset : 0
             if totalBytesExpectedToWrite > 0 {
                 progress.totalUnitCount = totalBytesExpectedToWrite + appliedOffset
             }
@@ -967,9 +1042,51 @@ public extension HubClient {
         func urlSession(
             _: URLSession,
             downloadTask _: URLSessionDownloadTask,
-            didFinishDownloadingTo _: URL
+            didResumeAtOffset fileOffset: Int64,
+            expectedTotalBytes: Int64
         ) {
-            // The actual file handling is done in the async/await layer
+            currentResumeOffset = fileOffset
+            progress.completedUnitCount = fileOffset
+            if expectedTotalBytes > 0 {
+                progress.totalUnitCount = expectedTotalBytes
+            }
+        }
+
+        func urlSession(
+            _: URLSession,
+            downloadTask: URLSessionDownloadTask,
+            didFinishDownloadingTo location: URL
+        ) {
+            guard let continuation, !hasResumed else { return }
+            hasResumed = true
+
+            guard let response = downloadTask.response else {
+                session?.invalidateAndCancel()
+                continuation.resume(throwing: URLError(.badServerResponse))
+                return
+            }
+
+            let persistedURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString)
+            do {
+                try? FileManager.default.removeItem(at: persistedURL)
+                try FileManager.default.moveItem(at: location, to: persistedURL)
+                if progress.totalUnitCount > 0 {
+                    progress.completedUnitCount = progress.totalUnitCount
+                }
+                session?.finishTasksAndInvalidate()
+                continuation.resume(returning: (persistedURL, response))
+            } catch {
+                session?.invalidateAndCancel()
+                continuation.resume(throwing: error)
+            }
+        }
+
+        func urlSession(_: URLSession, task _: URLSessionTask, didCompleteWithError error: Error?) {
+            guard let continuation, !hasResumed else { return }
+            hasResumed = true
+            session?.invalidateAndCancel()
+            continuation.resume(throwing: error ?? URLError(.badServerResponse))
         }
     }
 #endif

--- a/Tests/HuggingFaceTests/HubTests/FileOperationsTests.swift
+++ b/Tests/HuggingFaceTests/HubTests/FileOperationsTests.swift
@@ -960,6 +960,110 @@ import Testing
             #expect(try Data(contentsOf: cachedPath) == full)
         }
 
+        #if !canImport(FoundationNetworking)
+            @Test("downloadFile progress tracks final byte totals", .mockURLSession)
+            func testDownloadFileProgressTracksFinalByteTotals() async throws {
+                let fileBody = Data(repeating: 0xAB, count: 500)
+
+                await MockURLProtocol.setHandler { request in
+                    #expect(request.url?.path == "/user/model/resolve/main/large.bin")
+                    let response = HTTPURLResponse(
+                        url: request.url!,
+                        statusCode: 200,
+                        httpVersion: "HTTP/1.1",
+                        headerFields: [
+                            "Content-Type": "application/octet-stream",
+                            "Content-Length": "\(fileBody.count)",
+                        ]
+                    )!
+                    return (response, fileBody)
+                }
+
+                let client = createMockClientWithoutCache()
+                let destination = FileManager.default.temporaryDirectory
+                    .appendingPathComponent(UUID().uuidString)
+                defer { try? FileManager.default.removeItem(at: destination) }
+                let progress = Progress(totalUnitCount: 0)
+
+                let resolved = try await client.downloadFile(
+                    at: "large.bin",
+                    from: "user/model",
+                    to: destination,
+                    progress: progress
+                )
+
+                #expect(resolved == destination)
+                #expect(progress.totalUnitCount == Int64(fileBody.count))
+                #expect(progress.completedUnitCount == Int64(fileBody.count))
+                #expect(try Data(contentsOf: resolved) == fileBody)
+            }
+
+            @Test("downloadFile resumed progress includes existing bytes", .mockURLSession)
+            func testDownloadFileResumedProgressIncludesExistingBytes() async throws {
+                let commit = "1234567890123456789012345678901234567890"
+                let partial = Data("hello ".utf8)
+                let remainder = Data("world".utf8)
+                let full = Data("hello world".utf8)
+                let expectedRange = "bytes=\(partial.count)-"
+
+                await MockURLProtocol.setHandler { request in
+                    let path = request.url?.path ?? ""
+                    if path == "/user/model/resolve/main/test.txt" {
+                        if request.httpMethod == "HEAD" {
+                            let response = HTTPURLResponse(
+                                url: request.url!,
+                                statusCode: 200,
+                                httpVersion: "HTTP/1.1",
+                                headerFields: [
+                                    "ETag": "\"etag-123\"",
+                                    "X-Repo-Commit": commit,
+                                ]
+                            )!
+                            return (response, Data())
+                        }
+                        #expect(request.value(forHTTPHeaderField: "Range") == expectedRange)
+                        let response = HTTPURLResponse(
+                            url: request.url!,
+                            statusCode: 206,
+                            httpVersion: "HTTP/1.1",
+                            headerFields: [
+                                "Content-Type": "text/plain",
+                                "Content-Length": "\(remainder.count)",
+                            ]
+                        )!
+                        return (response, remainder)
+                    }
+                    let response = HTTPURLResponse(
+                        url: request.url!,
+                        statusCode: 404,
+                        httpVersion: "HTTP/1.1",
+                        headerFields: [:]
+                    )!
+                    return (response, Data())
+                }
+
+                let (client, cacheDirectory) = createMockClientWithCache()
+                defer { try? FileManager.default.removeItem(at: cacheDirectory) }
+                let repoID: Repo.ID = "user/model"
+                let cache = HubCache(cacheDirectory: cacheDirectory)
+                let blobsDir = cache.blobsDirectory(repo: repoID, kind: .model)
+                try FileManager.default.createDirectory(at: blobsDir, withIntermediateDirectories: true)
+                let incompletePath = blobsDir.appendingPathComponent("etag-123.incomplete")
+                try partial.write(to: incompletePath, options: .atomic)
+                let progress = Progress(totalUnitCount: 0)
+
+                let resolved = try await client.downloadFile(
+                    at: "test.txt",
+                    from: repoID,
+                    progress: progress
+                )
+
+                #expect(progress.totalUnitCount == Int64(full.count))
+                #expect(progress.completedUnitCount == Int64(full.count))
+                #expect(try Data(contentsOf: resolved) == full)
+            }
+        #endif
+
         @Test("downloadFile serializes concurrent resume before ranged request", .mockURLSession)
         func testDownloadFileConcurrentResumeSerializesRangedRequest() async throws {
             let commit = "1234567890123456789012345678901234567890"


### PR DESCRIPTION
> **Disclosure:** This fix was developed using Claude and Codex together in an iterative review cycle, then tested and validated by a human.

## Summary

- Fixes broken download progress reporting on Apple platforms (non-FoundationNetworking)
- The previous implementation used `session.download(for:delegate:)` but the delegate's `didFinishDownloadingTo` was a no-op, so progress never reached 100% and the temp file could be deleted before the caller processed it
- Replaces with a continuation-based `hfAsyncDownload` bridge that gives the delegate full ownership of the download lifecycle

## Changes

- **`HubClient+Files.swift`**: New `hfAsyncDownload` extension on `URLSession` using `withCheckedThrowingContinuation` + `withTaskCancellationHandler`. The `DownloadProgressDelegate` now persists the downloaded file, resumes the continuation on completion/error, and properly tracks resume offsets via `didResumeAtOffset`
- **`FileOperationsTests.swift`**: Two new tests — fresh download progress tracking and resumed (206) download progress with partial byte accounting

## Known edge case

The bridge creates a per-download `URLSession` from the original session's `configuration`. This means any caller-supplied session delegate (for auth challenges, redirect handling, metrics, or background-session behavior) is not carried over to download tasks. This is a standard pattern for delegate-owned async bridges, but worth noting for consumers who inject custom session delegates.

## Test plan

- [x] Full test suite passes (354 tests, 0 failures)
- [x] Manual validation of progress reporting during large model downloads