### PR TITLE
Fix decoding failure for `/api/models` responses with floating-point `trendingScore`

### DIFF
--- a/Sources/HuggingFace/Hub/Model.swift
+++ b/Sources/HuggingFace/Hub/Model.swift
@@ -51,7 +51,7 @@ public struct Model: Identifiable, Codable, Sendable {
     public let downloadsAllTime: Int?
 
     /// The trending score.
-    public let trendingScore: Int?
+    public let trendingScore: Double?
 
     /// The used storage in bytes.
     public let usedStorage: Int?


### PR DESCRIPTION
This PR fixes a decoding issue in `Model` where the `trendingScore` field was declared as `Int?`, while the Hugging Face Hub API may return floating-point values.

Actual response from `/api/models` for example:

```json
[
    {
        "_id": "65dee9413aec0530562b4f09",
        "id": "argmaxinc/whisperkit-coreml",
        "likes": 179,
        "trendingScore": 0.5,
        "private": false,
        "downloads": 10828425,
        "tags":
        [
            "whisperkit",
            "coreml",
            "whisper",
            "asr",
            "quantized",
            "automatic-speech-recognition",
            "region:us"
        ],
        "pipeline_tag": "automatic-speech-recognition",
        "library_name": "whisperkit",
        "createdAt": "2024-02-28T08:05:21.000Z",
        "modelId": "argmaxinc/whisperkit-coreml"
    },
    ...
]
```

Attempting to decode this into:

```swift
public let trendingScore: Int?
```

causes Swift's `JSONDecoder` to throw a `typeMismatch` decoding error. As a result, otherwise valid `listModels()` requests fail with `HTTPClientError.decodingError`

The change is backwards-compatible because JSON integer values also decode successfully into `Double`.
