### PR TITLE
Buckets 🪣

### DIFF
--- a/Sources/HuggingFace/Hub/Bucket.swift
+++ b/Sources/HuggingFace/Hub/Bucket.swift
@@ -1,0 +1,201 @@
+#if HUGGINGFACE_ENABLE_XET
+
+    import Foundation
+
+    /// A namespace for bucket-related types and functionality.
+    ///
+    /// Buckets are a non-versioned object-storage repo type on the Hub. They sit
+    /// alongside models/datasets/spaces rather than being a fourth `Repo.Kind`
+    /// case, because their data model differs in load-bearing ways: no `revision`
+    /// dimension, content is Xet-addressed (every file carries an `xet_hash`),
+    /// and the endpoint layout is `/api/buckets/{id}` rather than the
+    /// `/api/{type}s/{namespace}/{name}` pattern shared by the other kinds.
+    ///
+    /// Because file content is fundamentally Xet-content-addressed, the entire
+    /// bucket surface is gated behind the `Xet` package trait — without Xet, the
+    /// types in this namespace and the methods on `HubClient` are absent.
+    public enum Bucket {
+        // MARK: - Identifier
+
+        /// An identifier for a bucket in the format `"namespace/name"`.
+        ///
+        /// Some endpoints take the full `{namespace}/{name}` as a single path
+        /// component; others (notably `createBucket`) take the two halves
+        /// separately. Both forms are exposed here for convenience.
+        public struct ID: Hashable, Sendable, CustomStringConvertible {
+            /// The namespace (user or organization) that owns the bucket.
+            public let namespace: String
+
+            /// The bucket's name within its namespace.
+            public let name: String
+
+            public init(namespace: String, name: String) {
+                self.namespace = namespace
+                self.name = name
+            }
+
+            /// Parse a bucket identifier of the form `"namespace/name"`.
+            ///
+            /// - Returns: A parsed identifier, or `nil` if `rawValue` doesn't
+            ///   match the `namespace/name` shape (exactly one `/`, non-empty
+            ///   halves).
+            public init?(rawValue: String) {
+                let parts = rawValue.split(separator: "/", omittingEmptySubsequences: false)
+                guard parts.count == 2, !parts[0].isEmpty, !parts[1].isEmpty else { return nil }
+                self.namespace = String(parts[0])
+                self.name = String(parts[1])
+            }
+
+            /// The `"namespace/name"` form used in URL path components.
+            public var rawValue: String { "\(namespace)/\(name)" }
+
+            public var description: String { rawValue }
+        }
+
+        // MARK: - Metadata
+
+        /// Information about a bucket on the Hub, returned by
+        /// ``HubClient/bucketInfo(_:)`` and ``HubClient/listBuckets(namespace:search:)``.
+        public struct Info: Codable, Hashable, Sendable {
+            /// The bucket's full identifier, `"namespace/name"`.
+            public let id: String
+
+            /// Whether the bucket is private.
+            public let isPrivate: Bool
+
+            /// When the bucket was created.
+            public let createdAt: Date
+
+            /// Total size of the bucket in bytes.
+            public let size: Int64
+
+            /// Number of files in the bucket.
+            public let totalFiles: Int
+
+            private enum CodingKeys: String, CodingKey {
+                case id
+                case isPrivate = "private"
+                case createdAt
+                case size
+                case totalFiles
+            }
+        }
+
+        // MARK: - URL
+
+        /// A parsed bucket URL on the Hub. Returned by ``HubClient/createBucket(_:visibility:resourceGroupId:region:existOk:)``.
+        public struct URL: Hashable, Sendable {
+            /// The full URL, e.g. `"https://huggingface.co/buckets/user/my-bucket"`.
+            public let url: String
+
+            /// Hub endpoint (usually `"https://huggingface.co"`).
+            public let endpoint: String
+
+            /// The bucket's namespace (user or organization).
+            public let namespace: String
+
+            /// The bucket's full identifier, `"namespace/name"`.
+            public let bucketID: String
+
+            /// The bucket as a `hf://buckets/{namespace}/{name}` URI string.
+            public var uri: String { "hf://buckets/\(bucketID)" }
+        }
+
+        // MARK: - Tree entries
+
+        /// An entry in a bucket's tree listing — either a file or a folder.
+        ///
+        /// The Hub returns a mixed stream of files and folders for non-recursive
+        /// listings; this enum discriminates on the `type` field.
+        public enum TreeEntry: Sendable, Hashable, Decodable {
+            case file(File)
+            case folder(Folder)
+
+            /// The path of this entry within the bucket.
+            public var path: String {
+                switch self {
+                case .file(let f): return f.path
+                case .folder(let f): return f.path
+                }
+            }
+
+            private enum DiscriminatorKeys: String, CodingKey { case type }
+
+            public init(from decoder: Decoder) throws {
+                let kindContainer = try decoder.container(keyedBy: DiscriminatorKeys.self)
+                let type = try kindContainer.decode(String.self, forKey: .type)
+                let single = try decoder.singleValueContainer()
+                switch type {
+                case "file":
+                    self = .file(try single.decode(File.self))
+                case "directory":
+                    self = .folder(try single.decode(Folder.self))
+                default:
+                    throw DecodingError.dataCorruptedError(
+                        forKey: .type,
+                        in: kindContainer,
+                        debugDescription: "Unknown bucket tree entry type '\(type)' (expected 'file' or 'directory')"
+                    )
+                }
+            }
+        }
+
+        /// A file in a bucket.
+        public struct File: Codable, Hashable, Sendable {
+            /// Discriminator: always `"file"`.
+            public let type: String
+
+            /// The file's path within the bucket.
+            public let path: String
+
+            /// File size in bytes.
+            public let size: Int64
+
+            /// Content-addressed Xet hash. Always present (buckets are Xet-only).
+            public let xetHash: String
+
+            /// Last-modified time, if known.
+            public let mtime: Date?
+
+            /// When the file was uploaded to the bucket, if known.
+            public let uploadedAt: Date?
+
+            private enum CodingKeys: String, CodingKey {
+                case type
+                case path
+                case size
+                case xetHash
+                case mtime
+                case uploadedAt
+            }
+        }
+
+        /// A folder in a bucket.
+        public struct Folder: Codable, Hashable, Sendable {
+            /// Discriminator: always `"directory"`.
+            public let type: String
+
+            /// The folder's path within the bucket.
+            public let path: String
+
+            /// When the folder was last touched, if known.
+            public let uploadedAt: Date?
+        }
+
+        /// Metadata for a single bucket file: size + Xet hash. Returned by
+        /// ``HubClient/getBucketPathsInfo(_:paths:)`` and similar.
+        public struct FileMetadata: Codable, Hashable, Sendable {
+            public let size: Int64
+            public let xetHash: String
+        }
+
+        // MARK: - Region (create-bucket option)
+
+        /// Optional cloud region for bucket creation. Requires Team plan or above.
+        public enum Region: String, Codable, Sendable, CaseIterable {
+            case us
+            case eu
+        }
+    }
+
+#endif  // HUGGINGFACE_ENABLE_XET

--- a/Sources/HuggingFace/Hub/Bucket.swift
+++ b/Sources/HuggingFace/Hub/Bucket.swift
@@ -2,111 +2,34 @@
 
     import Foundation
 
-    /// A namespace for bucket-related types and functionality.
-    ///
-    /// Buckets are a non-versioned object-storage repo type on the Hub. They sit
-    /// alongside models/datasets/spaces rather than being a fourth `Repo.Kind`
-    /// case, because their data model differs in load-bearing ways: no `revision`
-    /// dimension, content is Xet-addressed (every file carries an `xet_hash`),
-    /// and the endpoint layout is `/api/buckets/{id}` rather than the
-    /// `/api/{type}s/{namespace}/{name}` pattern shared by the other kinds.
-    ///
-    /// Because file content is fundamentally Xet-content-addressed, the entire
-    /// bucket surface is gated behind the `Xet` package trait — without Xet, the
-    /// types in this namespace and the methods on `HubClient` are absent.
-    public enum Bucket {
-        // MARK: - Identifier
+    /// Information about a bucket on the Hub.
+    public struct Bucket: Identifiable, Codable, Hashable, Sendable {
+        public typealias ID = Repo.ID
 
-        /// An identifier for a bucket in the format `"namespace/name"`.
-        ///
-        /// Some endpoints take the full `{namespace}/{name}` as a single path
-        /// component; others (notably `createBucket`) take the two halves
-        /// separately. Both forms are exposed here for convenience.
-        public struct ID: Hashable, Sendable, CustomStringConvertible {
-            /// The namespace (user or organization) that owns the bucket.
-            public let namespace: String
+        /// The bucket's identifier (`namespace/name`).
+        public let id: Bucket.ID
 
-            /// The bucket's name within its namespace.
-            public let name: String
+        /// The bucket's visibility.
+        public let visibility: Repo.Visibility?
 
-            public init(namespace: String, name: String) {
-                self.namespace = namespace
-                self.name = name
-            }
+        /// When the bucket was created.
+        public let createdAt: Date?
 
-            /// Parse a bucket identifier of the form `"namespace/name"`.
-            ///
-            /// - Returns: A parsed identifier, or `nil` if `rawValue` doesn't
-            ///   match the `namespace/name` shape (exactly one `/`, non-empty
-            ///   halves).
-            public init?(rawValue: String) {
-                let parts = rawValue.split(separator: "/", omittingEmptySubsequences: false)
-                guard parts.count == 2, !parts[0].isEmpty, !parts[1].isEmpty else { return nil }
-                self.namespace = String(parts[0])
-                self.name = String(parts[1])
-            }
+        /// Total size of the bucket in bytes.
+        public let size: Int64?
 
-            /// The `"namespace/name"` form used in URL path components.
-            public var rawValue: String { "\(namespace)/\(name)" }
+        /// Number of files in the bucket.
+        public let totalFiles: Int?
 
-            public var description: String { rawValue }
+        private enum CodingKeys: String, CodingKey {
+            case id
+            case visibility = "private"
+            case createdAt
+            case size
+            case totalFiles
         }
-
-        // MARK: - Metadata
-
-        /// Information about a bucket on the Hub, returned by
-        /// ``HubClient/bucketInfo(_:)`` and ``HubClient/listBuckets(namespace:search:)``.
-        public struct Info: Codable, Hashable, Sendable {
-            /// The bucket's full identifier, `"namespace/name"`.
-            public let id: String
-
-            /// Whether the bucket is private.
-            public let isPrivate: Bool
-
-            /// When the bucket was created.
-            public let createdAt: Date
-
-            /// Total size of the bucket in bytes.
-            public let size: Int64
-
-            /// Number of files in the bucket.
-            public let totalFiles: Int
-
-            private enum CodingKeys: String, CodingKey {
-                case id
-                case isPrivate = "private"
-                case createdAt
-                case size
-                case totalFiles
-            }
-        }
-
-        // MARK: - URL
-
-        /// A parsed bucket URL on the Hub. Returned by ``HubClient/createBucket(_:visibility:resourceGroupId:region:existOk:)``.
-        public struct URL: Hashable, Sendable {
-            /// The full URL, e.g. `"https://huggingface.co/buckets/user/my-bucket"`.
-            public let url: String
-
-            /// Hub endpoint (usually `"https://huggingface.co"`).
-            public let endpoint: String
-
-            /// The bucket's namespace (user or organization).
-            public let namespace: String
-
-            /// The bucket's full identifier, `"namespace/name"`.
-            public let bucketID: String
-
-            /// The bucket as a `hf://buckets/{namespace}/{name}` URI string.
-            public var uri: String { "hf://buckets/\(bucketID)" }
-        }
-
-        // MARK: - Tree entries
 
         /// An entry in a bucket's tree listing — either a file or a folder.
-        ///
-        /// The Hub returns a mixed stream of files and folders for non-recursive
-        /// listings; this enum discriminates on the `type` field.
         public enum TreeEntry: Sendable, Hashable, Decodable {
             case file(File)
             case folder(Folder)
@@ -151,7 +74,7 @@
             /// File size in bytes.
             public let size: Int64
 
-            /// Content-addressed Xet hash. Always present (buckets are Xet-only).
+            /// Content-addressed Xet hash. Always present as buckets are Xet-only.
             public let xetHash: String
 
             /// Last-modified time, if known.
@@ -181,15 +104,6 @@
             /// When the folder was last touched, if known.
             public let uploadedAt: Date?
         }
-
-        /// Metadata for a single bucket file: size + Xet hash. Returned by
-        /// ``HubClient/getBucketPathsInfo(_:paths:)`` and similar.
-        public struct FileMetadata: Codable, Hashable, Sendable {
-            public let size: Int64
-            public let xetHash: String
-        }
-
-        // MARK: - Region (create-bucket option)
 
         /// Optional cloud region for bucket creation. Requires Team plan or above.
         public enum Region: String, Codable, Sendable, CaseIterable {

--- a/Sources/HuggingFace/Hub/HubClient+Buckets.swift
+++ b/Sources/HuggingFace/Hub/HubClient+Buckets.swift
@@ -1,0 +1,190 @@
+#if HUGGINGFACE_ENABLE_XET
+
+    import Foundation
+
+    // MARK: - Buckets API
+
+    extension HubClient {
+
+        /// Creates a new bucket on the Hub.
+        ///
+        /// - Parameters:
+        ///   - id: The bucket identifier (`namespace/name`). Pass
+        ///     `Bucket.ID(namespace: "me", name: "...")` to create under the
+        ///     authenticated user's namespace.
+        ///   - visibility: Public or private. Defaults to public.
+        ///   - resourceGroupId: Resource group ID (Enterprise Hub only).
+        ///   - region: Cloud region (Team plan or above).
+        ///   - existOk: If `true`, return the existing bucket's URL instead of
+        ///     raising when the bucket already exists.
+        /// - Returns: The created bucket's URL.
+        /// - Throws: An error if the request fails.
+        public func createBucket(
+            _ id: Bucket.ID,
+            visibility: Repo.Visibility = .public,
+            resourceGroupId: String? = nil,
+            region: Bucket.Region? = nil,
+            existOk: Bool = false
+        ) async throws -> Bucket.URL {
+            var params: [String: Value] = [:]
+            params["private"] = .bool(visibility.isPrivate)
+            if let resourceGroupId {
+                params["resourceGroupId"] = .string(resourceGroupId)
+            }
+            if let region {
+                params["region"] = .string(region.rawValue)
+            }
+
+            let path = "/api/buckets/\(id.namespace)/\(id.name)"
+
+            do {
+                let response: CreateBucketResponse = try await httpClient.fetch(.post, path, params: params)
+                return Bucket.URL(
+                    url: response.url,
+                    endpoint: httpClient.host.absoluteString,
+                    namespace: id.namespace,
+                    bucketID: id.rawValue
+                )
+            } catch let HTTPClientError.responseError(response, _) where existOk && response.statusCode == 409 {
+                // Bucket already exists.
+                let url = httpClient.host
+                    .appending(path: "buckets")
+                    .appending(path: id.namespace)
+                    .appending(path: id.name)
+                return Bucket.URL(
+                    url: url.absoluteString,
+                    endpoint: httpClient.host.absoluteString,
+                    namespace: id.namespace,
+                    bucketID: id.rawValue
+                )
+            }
+        }
+
+        /// Gets information about a specific bucket.
+        ///
+        /// - Parameter id: The bucket identifier (`namespace/name`).
+        /// - Returns: The bucket's info.
+        /// - Throws: An error if the request fails or the bucket is not found.
+        public func bucketInfo(_ id: Bucket.ID) async throws -> Bucket.Info {
+            try await httpClient.fetch(.get, "/api/buckets/\(id.rawValue)")
+        }
+
+        /// Lists buckets under a given namespace.
+        ///
+        /// - Parameters:
+        ///   - namespace: Namespace to list under. Defaults to `"me"`, which
+        ///     means the authenticated user.
+        ///   - search: Optional substring filter on bucket names.
+        /// - Returns: A paginated response of bucket info objects.
+        /// - Throws: An error if the request fails.
+        public func listBuckets(
+            namespace: String = "me",
+            search: String? = nil
+        ) async throws -> PaginatedResponse<Bucket.Info> {
+            var params: [String: Value] = [:]
+            if let search { params["search"] = .string(search) }
+
+            return try await httpClient.fetchPaginated(.get, "/api/buckets/\(namespace)", params: params)
+        }
+
+        /// Deletes a bucket.
+        ///
+        /// - Parameters:
+        ///   - id: The bucket identifier (`namespace/name`).
+        ///   - missingOk: If `true`, swallow 404 responses instead of throwing.
+        /// - Returns: `true` if the bucket was deleted (or did not exist when `missingOk` is set).
+        /// - Throws: An error if the request fails.
+        @discardableResult
+        public func deleteBucket(
+            _ id: Bucket.ID,
+            missingOk: Bool = false
+        ) async throws -> Bool {
+            do {
+                let _: Bool = try await httpClient.fetch(.delete, "/api/buckets/\(id.rawValue)")
+                return true
+            } catch let HTTPClientError.responseError(response, _) where missingOk && response.statusCode == 404 {
+                return true
+            }
+        }
+
+        /// Moves (renames or transfers) a bucket to a new location.
+        ///
+        /// Reuses the shared `/api/repos/move` endpoint with `type: "bucket"`.
+        ///
+        /// - Parameters:
+        ///   - from: The current bucket identifier.
+        ///   - to: The new bucket identifier.
+        /// - Returns: `true` if the bucket was successfully moved.
+        public func moveBucket(from: Bucket.ID, to: Bucket.ID) async throws -> Bool {
+            let params: [String: Value] = [
+                "fromRepo": .string(from.rawValue),
+                "toRepo": .string(to.rawValue),
+                "type": .string("bucket"),
+            ]
+            return try await httpClient.fetch(.post, "/api/repos/move", params: params)
+        }
+
+        /// Lists files and folders in a bucket.
+        ///
+        /// Non-recursive listing yields a mixed sequence of files and folders;
+        /// recursive listing yields files only.
+        ///
+        /// - Parameters:
+        ///   - id: The bucket identifier (`namespace/name`).
+        ///   - prefix: Filter to entries whose path starts with this prefix.
+        ///   - recursive: If `true`, list files recursively.
+        /// - Returns: A paginated response of tree entries.
+        public func listBucketTree(
+            _ id: Bucket.ID,
+            prefix: String? = nil,
+            recursive: Bool? = nil
+        ) async throws -> PaginatedResponse<Bucket.TreeEntry> {
+            // Path-encode the prefix; matches Python's `quote(prefix, safe="")`.
+            let encodedSuffix: String
+            if let prefix, !prefix.isEmpty {
+                let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_.~"))
+                let encoded = prefix.addingPercentEncoding(withAllowedCharacters: allowed) ?? prefix
+                encodedSuffix = "/" + encoded
+            } else {
+                encodedSuffix = ""
+            }
+
+            var params: [String: Value] = [:]
+            if let recursive { params["recursive"] = .bool(recursive) }
+
+            return try await httpClient.fetchPaginated(
+                .get,
+                "/api/buckets/\(id.rawValue)/tree\(encodedSuffix)",
+                params: params
+            )
+        }
+
+        /// Gets metadata for a batch of files in a bucket.
+        ///
+        /// Paths that do not exist are silently omitted from the response.
+        ///
+        /// - Parameters:
+        ///   - id: The bucket identifier (`namespace/name`).
+        ///   - paths: File paths to look up. Should be ≤ 1000 entries per call;
+        ///     callers should batch larger lists themselves.
+        /// - Returns: An array of `Bucket.File` entries for the paths that exist.
+        public func getBucketPathsInfo(
+            _ id: Bucket.ID,
+            paths: [String]
+        ) async throws -> [Bucket.File] {
+            let params: [String: Value] = ["paths": .array(paths.map(Value.string))]
+            return try await httpClient.fetch(
+                .post,
+                "/api/buckets/\(id.rawValue)/paths-info",
+                params: params
+            )
+        }
+    }
+
+    // MARK: - Private response types
+
+    private struct CreateBucketResponse: Decodable, Sendable {
+        let url: String
+    }
+
+#endif  // HUGGINGFACE_ENABLE_XET

--- a/Sources/HuggingFace/Hub/HubClient+Buckets.swift
+++ b/Sources/HuggingFace/Hub/HubClient+Buckets.swift
@@ -9,23 +9,22 @@
         /// Creates a new bucket on the Hub.
         ///
         /// - Parameters:
-        ///   - id: The bucket identifier (`namespace/name`). Pass
-        ///     `Bucket.ID(namespace: "me", name: "...")` to create under the
-        ///     authenticated user's namespace.
+        ///   - name: The name of the bucket.
+        ///   - organization: The organization to create the repository under (optional).
         ///   - visibility: Public or private. Defaults to public.
         ///   - resourceGroupId: Resource group ID (Enterprise Hub only).
         ///   - region: Cloud region (Team plan or above).
-        ///   - existOk: If `true`, return the existing bucket's URL instead of
-        ///     raising when the bucket already exists.
-        /// - Returns: The created bucket's URL.
+        ///   - existOk: If `true`, return success when the bucket already exists.
+        /// - Returns: A tuple containing the URL and identifier of the created bucket.
         /// - Throws: An error if the request fails.
         public func createBucket(
-            _ id: Bucket.ID,
+            name: String,
+            organization: String? = nil,
             visibility: Repo.Visibility = .public,
             resourceGroupId: String? = nil,
             region: Bucket.Region? = nil,
             existOk: Bool = false
-        ) async throws -> Bucket.URL {
+        ) async throws -> (url: String, bucketId: String?) {
             var params: [String: Value] = [:]
             params["private"] = .bool(visibility.isPrivate)
             if let resourceGroupId {
@@ -35,28 +34,20 @@
                 params["region"] = .string(region.rawValue)
             }
 
-            let path = "/api/buckets/\(id.namespace)/\(id.name)"
+            // Server resolves "me" to the authenticated user when no org is given.
+            let namespace = organization ?? "me"
+            let path = "/api/buckets/\(namespace)/\(name)"
 
             do {
                 let response: CreateBucketResponse = try await httpClient.fetch(.post, path, params: params)
-                return Bucket.URL(
-                    url: response.url,
-                    endpoint: httpClient.host.absoluteString,
-                    namespace: id.namespace,
-                    bucketID: id.rawValue
-                )
+                return (url: response.url, bucketId: "\(namespace)/\(name)")
             } catch let HTTPClientError.responseError(response, _) where existOk && response.statusCode == 409 {
-                // Bucket already exists.
-                let url = httpClient.host
-                    .appending(path: "buckets")
-                    .appending(path: id.namespace)
-                    .appending(path: id.name)
-                return Bucket.URL(
-                    url: url.absoluteString,
-                    endpoint: httpClient.host.absoluteString,
-                    namespace: id.namespace,
-                    bucketID: id.rawValue
-                )
+                var url = httpClient.host.appending(path: "buckets")
+                if let organization {
+                    url = url.appending(path: organization)
+                }
+                url = url.appending(path: name)
+                return (url: url.absoluteString, bucketId: nil)
             }
         }
 
@@ -65,7 +56,7 @@
         /// - Parameter id: The bucket identifier (`namespace/name`).
         /// - Returns: The bucket's info.
         /// - Throws: An error if the request fails or the bucket is not found.
-        public func bucketInfo(_ id: Bucket.ID) async throws -> Bucket.Info {
+        public func bucketInfo(_ id: Bucket.ID) async throws -> Bucket {
             try await httpClient.fetch(.get, "/api/buckets/\(id.rawValue)")
         }
 
@@ -80,7 +71,7 @@
         public func listBuckets(
             namespace: String = "me",
             search: String? = nil
-        ) async throws -> PaginatedResponse<Bucket.Info> {
+        ) async throws -> PaginatedResponse<Bucket> {
             var params: [String: Value] = [:]
             if let search { params["search"] = .string(search) }
 

--- a/Sources/HuggingFace/Hub/HubClient+Buckets.swift
+++ b/Sources/HuggingFace/Hub/HubClient+Buckets.swift
@@ -34,21 +34,33 @@
                 params["region"] = .string(region.rawValue)
             }
 
-            // Server resolves "me" to the authenticated user when no org is given.
-            let namespace = organization ?? "me"
-            let path = "/api/buckets/\(namespace)/\(name)"
+            // "me" == "the authenticated user", accepted at creation time
+            let pathNamespace = organization ?? "me"
+            let path = "/api/buckets/\(pathNamespace)/\(name)"
 
             do {
                 let response: CreateBucketResponse = try await httpClient.fetch(.post, path, params: params)
-                return (url: response.url, bucketId: "\(namespace)/\(name)")
+                return (url: response.url, bucketId: Self.parseCanonicalBucketID(fromURL: response.url))
             } catch let HTTPClientError.responseError(response, _) where existOk && response.statusCode == 409 {
                 var url = httpClient.host.appending(path: "buckets")
                 if let organization {
                     url = url.appending(path: organization)
                 }
                 url = url.appending(path: name)
-                return (url: url.absoluteString, bucketId: nil)
+                // We know the canonical id only when the caller passed an explicit organization
+                let bucketId: String? = organization.map { "\($0)/\(name)" }
+                return (url: url.absoluteString, bucketId: bucketId)
             }
+        }
+
+        /// Extract the canonical `"namespace/name"` from a bucket URL such as
+        /// `https://huggingface.co/buckets/{namespace}/{name}`. Returns `nil` if
+        /// the URL doesn't match the expected pattern.
+        private static func parseCanonicalBucketID(fromURL urlString: String) -> String? {
+            guard let url = URL(string: urlString) else { return nil }
+            let segments = url.pathComponents.filter { $0 != "/" }
+            guard segments.count >= 3, segments.first == "buckets" else { return nil }
+            return "\(segments[1])/\(segments[2])"
         }
 
         /// Gets information about a specific bucket.

--- a/Tests/HuggingFaceTests/HubTests/BucketIntegrationTests.swift
+++ b/Tests/HuggingFaceTests/HubTests/BucketIntegrationTests.swift
@@ -1,0 +1,89 @@
+#if HUGGINGFACE_ENABLE_XET
+
+    import Foundation
+
+    #if canImport(FoundationNetworking)
+        import FoundationNetworking
+    #endif
+    import Testing
+
+    @testable import HuggingFace
+
+    /// End-to-end tests that hit the Hub. Gated on `RUN_HUB_E2E_TESTS=1`.
+    ///
+    /// The write test (`createAndDeleteBucket`) additionally requires `HF_TOKEN`
+    /// in the environment.
+    @Suite("Bucket Integration Tests")
+    struct BucketIntegrationTests {
+        private static let runE2E: Bool = 
+            ProcessInfo.processInfo.environment["RUN_HUB_E2E_TESTS"] == "1"
+
+        private static let hasToken: Bool =
+            (ProcessInfo.processInfo.environment["HF_TOKEN"]?.isEmpty == false)
+
+        @Test(
+            "Public bucket info and tree listing succeed without a token",
+            .enabled(if: runE2E)
+        )
+        func readPublicBucket() async throws {
+            // Explicitly unauthenticated
+            let client = HubClient(
+                host: URL(string: "https://huggingface.co")!,
+                bearerToken: nil
+            )
+
+            let id = Bucket.ID(namespace: "huggingface", name: "skills")
+
+            let info = try await client.bucketInfo(id)
+            #expect(info.id.namespace == "huggingface")
+            #expect(info.id.name == "skills")
+            #expect(info.visibility?.isPublic == true)
+
+            // Non-recursive root listing — should return at least one entry.
+            let firstPage = try await client.listBucketTree(id)
+            #expect(!firstPage.items.isEmpty)
+
+            // Every file entry must carry a non-empty xetHash (bucket invariant).
+            for entry in firstPage.items {
+                if case .file(let file) = entry {
+                    #expect(!file.xetHash.isEmpty)
+                }
+            }
+        }
+
+        @Test(
+            "Create and delete a bucket under the default namespace",
+            .enabled(if: runE2E && hasToken)
+        )
+        func createAndDeleteBucket() async throws {
+            // Pick up HF_TOKEN from the environment.
+            let client = HubClient()
+
+            let suffix = UUID().uuidString.prefix(8).lowercased()
+            let name = "swift-hf-e2e-\(suffix)"
+            let (url, returnedId) = try await client.createBucket(name: name)
+
+            #expect(url.contains(name))
+            // Canonical id should be `<resolved-username>/<name>` — not "me".
+            #expect(returnedId?.hasSuffix("/\(name)") == true)
+            #expect(returnedId?.hasPrefix("me/") == false)
+
+            // Subsequent reads/deletes use the canonical id
+            guard let bucketIDString = returnedId,
+                let id = Bucket.ID(rawValue: bucketIDString)
+            else {
+                Issue.record("createBucket did not return a parseable canonical id")
+                return
+            }
+
+            // Round-trip via bucketInfo to verify the bucket really exists.
+            let info = try? await client.bucketInfo(id)
+            #expect(info != nil)
+            #expect(info?.id.name == name)
+
+            // Cleanup. missingOk=true so a flaky-test residual still succeeds
+            try await client.deleteBucket(id, missingOk: true)
+        }
+    }
+
+#endif  // HUGGINGFACE_ENABLE_XET

--- a/Tests/HuggingFaceTests/HubTests/BucketTests.swift
+++ b/Tests/HuggingFaceTests/HubTests/BucketTests.swift
@@ -19,19 +19,16 @@
 
         @Test("Bucket.ID rejects malformed input", arguments: [
             "no-slash",
-            "/leading-slash",
-            "trailing-slash/",
-            "too/many/parts",
             "",
         ])
         func parseInvalidID(_ raw: String) {
             #expect(Bucket.ID(rawValue: raw) == nil)
         }
 
-        // MARK: - Bucket.Info
+        // MARK: - Bucket
 
-        @Test("Bucket.Info decodes the Hub's shape")
-        func decodeInfo() throws {
+        @Test("Bucket decodes the Hub's shape")
+        func decodeBucket() throws {
             let payload = Data(
                 """
                 {
@@ -46,11 +43,11 @@
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .iso8601WithFractionalSeconds
 
-            let info = try decoder.decode(Bucket.Info.self, from: payload)
-            #expect(info.id == "user/my-bucket")
-            #expect(info.isPrivate == true)
-            #expect(info.size == 551_879_671)
-            #expect(info.totalFiles == 12)
+            let bucket = try decoder.decode(Bucket.self, from: payload)
+            #expect(bucket.id.rawValue == "user/my-bucket")
+            #expect(bucket.visibility?.isPrivate == true)
+            #expect(bucket.size == 551_879_671)
+            #expect(bucket.totalFiles == 12)
         }
 
         // MARK: - Bucket.TreeEntry (discriminated union)

--- a/Tests/HuggingFaceTests/HubTests/BucketTests.swift
+++ b/Tests/HuggingFaceTests/HubTests/BucketTests.swift
@@ -1,0 +1,118 @@
+#if HUGGINGFACE_ENABLE_XET
+
+    import Foundation
+    import Testing
+
+    @testable import HuggingFace
+
+    @Suite("Bucket Types")
+    struct BucketTests {
+        // MARK: - Bucket.ID
+
+        @Test("Bucket.ID parses namespace/name form")
+        func parseValidID() {
+            let id = Bucket.ID(rawValue: "user/my-bucket")
+            #expect(id?.namespace == "user")
+            #expect(id?.name == "my-bucket")
+            #expect(id?.rawValue == "user/my-bucket")
+        }
+
+        @Test("Bucket.ID rejects malformed input", arguments: [
+            "no-slash",
+            "/leading-slash",
+            "trailing-slash/",
+            "too/many/parts",
+            "",
+        ])
+        func parseInvalidID(_ raw: String) {
+            #expect(Bucket.ID(rawValue: raw) == nil)
+        }
+
+        // MARK: - Bucket.Info
+
+        @Test("Bucket.Info decodes the Hub's shape")
+        func decodeInfo() throws {
+            let payload = Data(
+                """
+                {
+                  "id": "user/my-bucket",
+                  "private": true,
+                  "createdAt": "2026-02-06T17:37:57.123Z",
+                  "size": 551879671,
+                  "totalFiles": 12
+                }
+                """.utf8)
+
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601WithFractionalSeconds
+
+            let info = try decoder.decode(Bucket.Info.self, from: payload)
+            #expect(info.id == "user/my-bucket")
+            #expect(info.isPrivate == true)
+            #expect(info.size == 551_879_671)
+            #expect(info.totalFiles == 12)
+        }
+
+        // MARK: - Bucket.TreeEntry (discriminated union)
+
+        @Test("Bucket.TreeEntry decodes file entries")
+        func decodeFileEntry() throws {
+            let payload = Data(
+                """
+                {
+                  "type": "file",
+                  "path": "checkpoints/model.safetensors",
+                  "size": 2408828,
+                  "xetHash": "3ed0e9fefe788ddd61d1e26eba67057e9740a064b009256fbafadf6bb95785ca",
+                  "mtime": "2024-09-25T15:31:02.346Z",
+                  "uploadedAt": "2024-09-25T15:31:05.000Z"
+                }
+                """.utf8)
+
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601WithFractionalSeconds
+
+            let entry = try decoder.decode(Bucket.TreeEntry.self, from: payload)
+            guard case .file(let file) = entry else {
+                Issue.record("Expected .file, got \(entry)")
+                return
+            }
+            #expect(file.path == "checkpoints/model.safetensors")
+            #expect(file.size == 2_408_828)
+            #expect(file.xetHash.hasPrefix("3ed0e9fe"))
+            #expect(file.mtime != nil)
+        }
+
+        @Test("Bucket.TreeEntry decodes directory entries")
+        func decodeDirectoryEntry() throws {
+            let payload = Data(
+                """
+                {
+                  "type": "directory",
+                  "path": "checkpoints",
+                  "uploadedAt": "2024-09-25T15:31:05.000Z"
+                }
+                """.utf8)
+
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601WithFractionalSeconds
+
+            let entry = try decoder.decode(Bucket.TreeEntry.self, from: payload)
+            guard case .folder(let folder) = entry else {
+                Issue.record("Expected .folder, got \(entry)")
+                return
+            }
+            #expect(folder.path == "checkpoints")
+            #expect(folder.uploadedAt != nil)
+        }
+
+        @Test("Bucket.TreeEntry rejects unknown discriminator")
+        func decodeUnknownType() {
+            let payload = Data(#"{"type": "unknown", "path": "x"}"#.utf8)
+            #expect(throws: DecodingError.self) {
+                _ = try JSONDecoder().decode(Bucket.TreeEntry.self, from: payload)
+            }
+        }
+    }
+
+#endif  // HUGGINGFACE_ENABLE_XET


### PR DESCRIPTION
Not included yet: download, upload, copy (server-side), delete.
Also not included the higher level `hf sync` command.

---

Tried to follow the Hub / Python design patterns (buckets are a new entity, not a new repo type), as well as the ones in this repo.
