### PR TITLE
Validate paths in HubCache.cachedFilePath and resolveRevision

### DIFF
--- a/Sources/HuggingFace/Hub/HubCache.swift
+++ b/Sources/HuggingFace/Hub/HubCache.swift
@@ -177,7 +177,12 @@ public struct HubCache: Sendable {
     ///   - ref: The reference name (e.g., "main").
     /// - Returns: The commit hash if found, `nil` otherwise.
     public func resolveRevision(repo: Repo.ID, kind: Repo.Kind, ref: String) -> String? {
-        let refFile = refsDirectory(repo: repo, kind: kind).appendingPathComponent(ref)
+        let refsDirectory = refsDirectory(repo: repo, kind: kind)
+        // Refs may be nested (e.g. "refs/pr/5"), but must stay within the refs directory.
+        guard (try? validateFilename(ref, withinDirectory: refsDirectory)) != nil else {
+            return nil
+        }
+        let refFile = refsDirectory.appendingPathComponent(ref)
         guard let contents = try? String(contentsOf: refFile, encoding: .utf8) else {
             return nil
         }
@@ -235,7 +240,14 @@ public struct HubCache: Sendable {
             return nil
         }
 
-        let snapshotFile = snapshotsDirectory(repo: repo, kind: kind)
+        let snapshotsDirectory = snapshotsDirectory(repo: repo, kind: kind)
+        // Reject filenames that would escape the cache directory (e.g. "../../secret").
+        guard (try? validateFilename(filename, withinDirectory: snapshotsDirectory)) != nil else {
+            return nil
+        }
+
+        let snapshotFile =
+            snapshotsDirectory
             .appendingPathComponent(commitHash)
             .appendingPathComponent(filename)
 

--- a/Tests/HuggingFaceTests/HubTests/HubCacheTests.swift
+++ b/Tests/HuggingFaceTests/HubTests/HubCacheTests.swift
@@ -1007,4 +1007,71 @@ struct HubCacheTests {
         )
         #expect(cachedPath != nil)
     }
+
+    // MARK: - Cache Lookup Path Traversal Validation Tests
+
+    @Test("Cached file path rejects filename with path traversal")
+    func cachedFilePathRejectsFilenamePathTraversal() throws {
+        let cacheDirectory = tempDirectory.appendingPathComponent("cache", isDirectory: true)
+        let cache = HubCache(cacheDirectory: cacheDirectory)
+        let repoID: Repo.ID = "user/repo"
+        let commitHash = "abc123def456789012345678901234567890abcd"
+
+        // A file that lives outside the cache directory.
+        let outsideFile = tempDirectory.appendingPathComponent("secret.txt")
+        try "secret".write(to: outsideFile, atomically: true, encoding: .utf8)
+
+        // Make sure the snapshot directory exists so only the filename is suspect.
+        let snapshotDirectory = cache.snapshotsDirectory(repo: repoID, kind: .model)
+            .appendingPathComponent(commitHash)
+        try FileManager.default.createDirectory(at: snapshotDirectory, withIntermediateDirectories: true)
+
+        // snapshots/<commit>/../../../../secret.txt resolves to the file outside the cache.
+        let cachedPath = cache.cachedFilePath(
+            repo: repoID,
+            kind: .model,
+            revision: commitHash,
+            filename: "../../../../secret.txt"
+        )
+
+        #expect(cachedPath == nil)
+    }
+
+    @Test("Cached file path rejects revision with path traversal")
+    func cachedFilePathRejectsRevisionPathTraversal() throws {
+        let cacheDirectory = tempDirectory.appendingPathComponent("cache", isDirectory: true)
+        let cache = HubCache(cacheDirectory: cacheDirectory)
+        let repoID: Repo.ID = "user/repo"
+        let commitHash = "abc123def456789012345678901234567890abcd"
+
+        // A legitimately cached snapshot file.
+        let snapshotDirectory = cache.snapshotsDirectory(repo: repoID, kind: .model)
+            .appendingPathComponent(commitHash)
+        try FileManager.default.createDirectory(at: snapshotDirectory, withIntermediateDirectories: true)
+        try "content".write(
+            to: snapshotDirectory.appendingPathComponent("config.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        // The refs directory must exist for `..` components to resolve through it.
+        try FileManager.default.createDirectory(
+            at: cache.refsDirectory(repo: repoID, kind: .model),
+            withIntermediateDirectories: true
+        )
+
+        // A "ref" file outside the cache directory that points at that commit.
+        let outsideRef = tempDirectory.appendingPathComponent("evil-ref")
+        try commitHash.write(to: outsideRef, atomically: true, encoding: .utf8)
+
+        // refs/../../../evil-ref resolves to the file outside the cache.
+        let cachedPath = cache.cachedFilePath(
+            repo: repoID,
+            kind: .model,
+            revision: "../../../evil-ref",
+            filename: "config.json"
+        )
+
+        #expect(cachedPath == nil)
+    }
 }


### PR DESCRIPTION
Fixes #62.

`HubCache.cachedFilePath(repo:kind:revision:filename:)` and `resolveRevision(repo:kind:ref:)` built paths from the caller-supplied `filename` / `revision` without the validation that `storeFile` and `storeData` already perform. A component containing `..` could therefore resolve to — and, via `downloadFile`, be read from — a location outside the cache directory.

This applies the same `validateFilename(_:withinDirectory:)` check in both places and returns `nil` for anything that would escape the cache. Nested refs like `refs/pr/5` continue to work.