### PR TITLE
Remove the download temp file after storing it in the cache

### DIFF
--- a/Sources/HuggingFace/Hub/HubClient+Files.swift
+++ b/Sources/HuggingFace/Hub/HubClient+Files.swift
@@ -703,6 +703,8 @@ public extension HubClient {
                             revision: commitHash,
                             filename: repoPath
                         ) {
+                            // The file was copied into the cache; the download temp file is no longer needed.
+                            try? FileManager.default.removeItem(at: tempURL)
                             return try copyFileToDestinationIfNeeded(
                                 cachedPath,
                                 destination: destination
@@ -791,6 +793,8 @@ public extension HubClient {
                 revision: commitHash,
                 filename: repoPath
             ) {
+                // The file was copied into the cache; the download temp file is no longer needed.
+                try? FileManager.default.removeItem(at: tempURL)
                 return try copyFileToDestinationIfNeeded(
                     cachedPath,
                     destination: destination

--- a/Tests/HuggingFaceTests/HubTests/FileOperationsTests.swift
+++ b/Tests/HuggingFaceTests/HubTests/FileOperationsTests.swift
@@ -2149,6 +2149,83 @@ import Testing
 
         // MARK: - Error Handling Tests
 
+        // MARK: - Temporary File Cleanup Tests
+
+        /// Returns the URLSession download temp files currently in the temporary directory.
+        func downloadTempFiles() -> Set<String> {
+            let contents =
+                (try? FileManager.default.contentsOfDirectory(atPath: FileManager.default.temporaryDirectory.path))
+                ?? []
+            return Set(contents.filter { $0.hasPrefix("CFNetworkDownload_") })
+        }
+
+        /// Waits briefly for any download temp files created since `before` to be removed.
+        func newDownloadTempFiles(since before: Set<String>) async -> Set<String> {
+            for _ in 0 ..< 20 {
+                let new = downloadTempFiles().subtracting(before)
+                if new.isEmpty { return new }
+                try? await Task.sleep(nanoseconds: 100_000_000)
+            }
+            return downloadTempFiles().subtracting(before)
+        }
+
+        @Test("downloadFile removes the download temp file after caching (ETag flow)", .mockURLSession)
+        func testDownloadFileRemovesTempFileAfterCachingWithETag() async throws {
+            let commit = "1234567890123456789012345678901234567890"
+            await MockURLProtocol.setHandler { request in
+                let headers = [
+                    "ETag": "\"etag-123\"",
+                    "X-Repo-Commit": commit,
+                    "Content-Type": "text/plain",
+                ]
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 200,
+                    httpVersion: "HTTP/1.1",
+                    headerFields: headers
+                )!
+                return (response, request.httpMethod == "HEAD" ? Data() : Data("content".utf8))
+            }
+
+            let (client, cacheDirectory) = createMockClientWithCache()
+            defer { try? FileManager.default.removeItem(at: cacheDirectory) }
+
+            let before = downloadTempFiles()
+            _ = try await client.downloadFile(at: "test.txt", from: "user/model", revision: "main")
+
+            let leaked = await newDownloadTempFiles(since: before)
+            #expect(leaked.isEmpty, "Leaked download temp files: \(leaked)")
+        }
+
+        @Test("downloadFile removes the download temp file after caching (fallback flow)", .mockURLSession)
+        func testDownloadFileRemovesTempFileAfterCachingWithoutPreflightMetadata() async throws {
+            let commit = "1234567890123456789012345678901234567890"
+            await MockURLProtocol.setHandler { request in
+                // HEAD carries no cache metadata, so the generic fallback path is used;
+                // the GET response carries it, so the file is still stored in the cache.
+                let headers: [String: String] =
+                    request.httpMethod == "HEAD"
+                    ? ["Content-Type": "text/plain"]
+                    : ["ETag": "\"etag-123\"", "X-Repo-Commit": commit, "Content-Type": "text/plain"]
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 200,
+                    httpVersion: "HTTP/1.1",
+                    headerFields: headers
+                )!
+                return (response, request.httpMethod == "HEAD" ? Data() : Data("content".utf8))
+            }
+
+            let (client, cacheDirectory) = createMockClientWithCache()
+            defer { try? FileManager.default.removeItem(at: cacheDirectory) }
+
+            let before = downloadTempFiles()
+            _ = try await client.downloadFile(at: "test.txt", from: "user/model", revision: "main")
+
+            let leaked = await newDownloadTempFiles(since: before)
+            #expect(leaked.isEmpty, "Leaked download temp files: \(leaked)")
+        }
+
         @Test("Handle network error", .mockURLSession)
         func testNetworkError() async throws {
             await MockURLProtocol.setHandler { request in


### PR DESCRIPTION
Fixes #52.

`HubCache.storeFile` copies the `URLSession` download temp file into the blob cache, but on the success path the temp file itself was never removed, so every cached download left a `CFNetworkDownload_*.tmp` behind in the temporary directory.

This removes the temp file once the cache copy has succeeded, in both the ETag-aware download path and the generic fallback. The other branches (resume merge, error, and move-to-destination) already handled it.
