### PR TITLE
Give persisted download temp files a recognizable name

### DIFF
--- a/Sources/HuggingFace/Hub/HubClient+Files.swift
+++ b/Sources/HuggingFace/Hub/HubClient+Files.swift
@@ -948,7 +948,7 @@ public extension HubClient {
         var task: URLSessionDownloadTask?
     }
 
-    private extension URLSession {
+    extension URLSession {
         func hfAsyncDownload(
             for request: URLRequest,
             progress: Progress? = nil,
@@ -1070,8 +1070,9 @@ public extension HubClient {
                 return
             }
 
+            // Use a recognizable name so stray files are easy to attribute (see #52).
             let persistedURL = FileManager.default.temporaryDirectory
-                .appendingPathComponent(UUID().uuidString)
+                .appendingPathComponent("hf-download-\(UUID().uuidString).tmp")
             do {
                 try? FileManager.default.removeItem(at: persistedURL)
                 try FileManager.default.moveItem(at: location, to: persistedURL)

--- a/Tests/HuggingFaceTests/HubTests/FileOperationsTests.swift
+++ b/Tests/HuggingFaceTests/HubTests/FileOperationsTests.swift
@@ -2260,7 +2260,7 @@ import Testing
             let contents =
                 (try? FileManager.default.contentsOfDirectory(atPath: FileManager.default.temporaryDirectory.path))
                 ?? []
-            return Set(contents.filter { $0.hasPrefix("CFNetworkDownload_") })
+            return Set(contents.filter { $0.hasPrefix("CFNetworkDownload_") || $0.hasPrefix("hf-download-") })
         }
 
         /// Waits briefly for any download temp files created since `before` to be removed.
@@ -2272,6 +2272,33 @@ import Testing
             }
             return downloadTempFiles().subtracting(before)
         }
+
+        #if !canImport(FoundationNetworking)
+            @Test("Download temp file has a recognizable name", .mockURLSession)
+            func testDownloadTempFileHasRecognizableName() async throws {
+                await MockURLProtocol.setHandler { request in
+                    let response = HTTPURLResponse(
+                        url: request.url!,
+                        statusCode: 200,
+                        httpVersion: "HTTP/1.1",
+                        headerFields: ["Content-Type": "text/plain"]
+                    )!
+                    return (response, Data("content".utf8))
+                }
+
+                let configuration = URLSessionConfiguration.ephemeral
+                configuration.protocolClasses = [MockURLProtocol.self]
+                let session = URLSession(configuration: configuration)
+                let request = URLRequest(url: URL(string: "https://huggingface.co/user/model/resolve/main/test.txt")!)
+
+                let (tempURL, _) = try await session.hfAsyncDownload(for: request)
+                defer { try? FileManager.default.removeItem(at: tempURL) }
+
+                #expect(tempURL.lastPathComponent.hasPrefix("hf-download-"))
+                #expect(tempURL.pathExtension == "tmp")
+                #expect(tempURL.deletingLastPathComponent().path == FileManager.default.temporaryDirectory.path)
+            }
+        #endif
 
         @Test("downloadFile removes the download temp file after caching (ETag flow)", .mockURLSession)
         func testDownloadFileRemovesTempFileAfterCachingWithETag() async throws {


### PR DESCRIPTION
Follow-up to #50, as mentioned in https://github.com/huggingface/swift-huggingface/pull/50#pullrequestreview-5089132361.

The download bridge moves each finished download to a bare UUID in the temporary directory. This names it `hf-download-<uuid>.tmp` instead, so that any stray file is easy to attribute (the leak in #52 was only noticed because `CFNetworkDownload_*.tmp` is a recognizable name), and has the temp-file cleanup tests from #65 watch for that prefix as well.

`hfAsyncDownload` becomes internal rather than fileprivate so the naming test can call it directly.
