### PR TITLE
Add Swift 6.3 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,14 @@ jobs:
             xcode: "26.0"
             macos: "26"
             traits: "Xet"
+          - swift: "6.3"
+            xcode: "26.6"
+            macos: "26"
+            traits: ""
+          - swift: "6.3"
+            xcode: "26.6"
+            macos: "26"
+            traits: "Xet"
     timeout-minutes: 10
     steps:
       - name: Checkout code
@@ -72,6 +80,10 @@ jobs:
           - swift: "6.2.3"
             traits: ""
           - swift: "6.2.3"
+            traits: "Xet"
+          - swift: "6.3.3"
+            traits: ""
+          - swift: "6.3.3"
             traits: "Xet"
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
Adds Swift 6.3 to the CI matrix:

- macOS: Xcode 26.6 (Swift 6.3.3) on `macos-26`, with and without `--traits Xet`
- Linux: `swift:6.3.3`, with and without `--traits Xet`

Xcode 26.4 was the first to ship Swift 6.3; 26.6 is the current default on the `macos-26` runner image and matches the latest Linux tag.
