### PR TITLE
Make the non-blocking FileLock test deterministic

### DIFF
--- a/Tests/HuggingFaceTests/HubTests/FileLockTests.swift
+++ b/Tests/HuggingFaceTests/HubTests/FileLockTests.swift
@@ -295,19 +295,20 @@ struct FileLockTests {
         await holdingLock.wait(timeout: 5)
         #expect(holdingLock.isFulfilled)
 
-        let lock2 = FileLock(path: targetPath, blocking: false)
-        let startTime = ContinuousClock.now
+        // A long retry delay and a retry cap make a regression (retrying despite
+        // `blocking: false`) show up as `attempts > 1` rather than as a hang.
+        let lock2 = FileLock(path: targetPath, maxRetries: 1, retryDelay: 10, blocking: false)
         var didFail = false
         do {
             _ = try await lock2.withLock {
                 Issue.record("non-blocking lock should have failed")
             }
-        } catch is FileLockError {
+        } catch FileLockError.acquisitionFailed(_, let attempts, let totalWaitTime) {
             didFail = true
+            #expect(attempts == 1)
+            #expect(totalWaitTime == 0)
         }
-        let elapsed = ContinuousClock.now - startTime
         #expect(didFail)
-        #expect(elapsed < .milliseconds(100))
     }
 
     @Test("Non-blocking mode succeeds when lock is available")


### PR DESCRIPTION
`nonBlockingMode` asserted that a non-blocking acquisition attempt returns within 100ms of wall-clock time. That measures runner scheduling rather than the lock's behavior, and it [failed once](https://github.com/huggingface/swift-huggingface/actions/runs/33628310802) on `main` on Linux (re-running passed).

The non-blocking path does one `flock(LOCK_NB)` and throws, so the property worth asserting is on the error itself: exactly one attempt and zero wait time. A large `retryDelay` with `maxRetries: 1` turns a regression (retrying despite `blocking: false`) into a visible `attempts > 1` failure instead of a hang. I verified the new assertion fails against such a regression before reverting it.
