### PR TITLE
Report per-file progress from downloadSnapshot

### DIFF
--- a/Sources/HuggingFace/Hub/HubClient+Files.swift
+++ b/Sources/HuggingFace/Hub/HubClient+Files.swift
@@ -16,6 +16,89 @@ import Foundation
 private let xetMinimumFileSizeBytes = 16 * 1024 * 1024  // 16MiB
 private let snapshotUnknownFileWeight: Int64 = 1
 
+/// Per-file progress for a snapshot download, delivered alongside the
+/// aggregate `Progress`. The downloader already tracks a child `Progress` per
+/// file to weight the aggregate; this exposes it so a caller can render one row
+/// per file instead of a single aggregate bar.
+///
+/// Sampled by the same 100 ms task that drives `progressHandler`, plus a final
+/// emission once the download succeeds. A snapshot served entirely from cache
+/// emits one complete set of rows and nothing else; a download that throws or
+/// is cancelled emits no terminal set, matching `progressHandler`.
+///
+/// Additive and opt-in (default `fileProgressHandler: nil` ⇒ no behavior change).
+public struct SnapshotFileProgress: Sendable {
+    /// Repo-relative file path (e.g. `model-00001-of-00006.safetensors`).
+    public let path: String
+    /// Size in bytes as declared by the repo's tree listing, or `nil` when the
+    /// listing does not declare one.
+    ///
+    /// This is the tree entry's own value, not a running count: it is stable
+    /// for the whole download and is the figure to render a row's total from.
+    /// The per-file byte counters the transports maintain internally are not
+    /// published, because they are not uniformly bytes — Xet reports a file as
+    /// `100/100` on completion regardless of its size.
+    public let sizeBytes: Int64?
+    /// Fraction of this file transferred, in `0.0...1.0`.
+    ///
+    /// Read from the file's `Progress` in one access, so it is never a torn
+    /// pair of counters. Transports differ in how often they revise it: an LFS
+    /// download advances it per delegate callback, while a Xet download reports
+    /// nothing until the file completes.
+    public let fractionCompleted: Double
+}
+
+private func snapshotFileProgress(
+    _ rows: [(path: String, size: Int64?, progress: SnapshotProgressBox)]
+) -> [SnapshotFileProgress] {
+    rows.map { row in
+        SnapshotFileProgress(
+            path: row.path,
+            sizeBytes: row.size,
+            fractionCompleted: row.progress.value.fractionCompleted
+        )
+    }
+}
+
+/// Complete rows synthesized for a snapshot that was served from cache without
+/// downloading anything, so a caller that renders rows sees the same terminal
+/// state it would get from a real download.
+private func cachedSnapshotFileProgress(at root: URL, matching globs: [String]) -> [SnapshotFileProgress] {
+    let base = root.standardizedFileURL
+    guard
+        let enumerator = FileManager.default.enumerator(
+            at: base,
+            includingPropertiesForKeys: [.isDirectoryKey]
+        )
+    else { return [] }
+    let prefix = base.path.hasSuffix("/") ? base.path : base.path + "/"
+    return enumerator.compactMap { element in
+        guard let url = element as? URL else { return nil }
+        // Cache snapshots are trees of symlinks into the blob store, so resolve
+        // before asking whether this is a file and how big it is.
+        let target = url.resolvingSymlinksInPath()
+        var isDirectory: ObjCBool = false
+        guard
+            FileManager.default.fileExists(atPath: target.path, isDirectory: &isDirectory),
+            !isDirectory.boolValue
+        else { return nil }
+        let fullPath = url.standardizedFileURL.path
+        let path =
+            fullPath.hasPrefix(prefix)
+            ? String(fullPath.dropFirst(prefix.count))
+            : url.lastPathComponent
+        guard globs.isEmpty || globs.contains(where: { fnmatch($0, path, 0) == 0 }) else {
+            return nil
+        }
+        let size = (try? FileManager.default.attributesOfItem(atPath: target.path))?[.size] as? NSNumber
+        return SnapshotFileProgress(
+            path: path,
+            sizeBytes: size.map { Int64(truncating: $0) },
+            fractionCompleted: 1.0
+        )
+    }
+}
+
 private final class SnapshotProgressBox: @unchecked Sendable {
     let value: Progress
 
@@ -1270,6 +1353,10 @@ public extension HubClient {
     ///   - localFilesOnly: When `true`, resolve only from local cache and throw if missing.
     ///   - progressHandler: Optional closure called with progress updates.
     ///     Updates are delivered on the main actor.
+    ///   - fileProgressHandler: Optional closure called with one
+    ///     ``SnapshotFileProgress`` per file, sampled on the same schedule as
+    ///     `progressHandler`. Delivered on the main actor. A snapshot served
+    ///     from cache emits a single complete set of rows.
     /// - Returns: URL to `destination`.
     func downloadSnapshot(
         of repo: Repo.ID,
@@ -1279,7 +1366,8 @@ public extension HubClient {
         matching globs: [String] = [],
         localFilesOnly: Bool = false,
         maxConcurrentDownloads: Int = 8,
-        progressHandler: (@MainActor @Sendable (Progress) -> Void)? = nil
+        progressHandler: (@MainActor @Sendable (Progress) -> Void)? = nil,
+        fileProgressHandler: (@MainActor @Sendable ([SnapshotFileProgress]) -> Void)? = nil
     ) async throws -> URL {
         try await downloadSnapshot(
             of: repo,
@@ -1290,7 +1378,8 @@ public extension HubClient {
             returnCachePath: false,
             localFilesOnly: localFilesOnly,
             maxConcurrentDownloads: maxConcurrentDownloads,
-            progressHandler: progressHandler
+            progressHandler: progressHandler,
+            fileProgressHandler: fileProgressHandler
         )
     }
 
@@ -1311,6 +1400,10 @@ public extension HubClient {
     ///                             The default value is 8. Values less than 1 are treated as 1.
     ///   - progressHandler: Optional closure called with progress updates.
     ///     Updates are delivered on the main actor.
+    ///   - fileProgressHandler: Optional closure called with one
+    ///     ``SnapshotFileProgress`` per file, sampled on the same schedule as
+    ///     `progressHandler`. Delivered on the main actor. A snapshot served
+    ///     from cache emits a single complete set of rows.
     /// - Returns: URL to the cache snapshot directory.
     func downloadSnapshot(
         of repo: Repo.ID,
@@ -1319,7 +1412,8 @@ public extension HubClient {
         matching globs: [String] = [],
         localFilesOnly: Bool = false,
         maxConcurrentDownloads: Int = 8,
-        progressHandler: (@MainActor @Sendable (Progress) -> Void)? = nil
+        progressHandler: (@MainActor @Sendable (Progress) -> Void)? = nil,
+        fileProgressHandler: (@MainActor @Sendable ([SnapshotFileProgress]) -> Void)? = nil
     ) async throws -> URL {
         try await downloadSnapshot(
             of: repo,
@@ -1330,7 +1424,8 @@ public extension HubClient {
             returnCachePath: true,
             localFilesOnly: localFilesOnly,
             maxConcurrentDownloads: maxConcurrentDownloads,
-            progressHandler: progressHandler
+            progressHandler: progressHandler,
+            fileProgressHandler: fileProgressHandler
         )
     }
 
@@ -1343,7 +1438,8 @@ public extension HubClient {
         returnCachePath: Bool,
         localFilesOnly: Bool,
         maxConcurrentDownloads: Int,
-        progressHandler: (@MainActor @Sendable (Progress) -> Void)?
+        progressHandler: (@MainActor @Sendable (Progress) -> Void)?,
+        fileProgressHandler: (@MainActor @Sendable ([SnapshotFileProgress]) -> Void)?
     ) async throws -> URL {
         let maxConcurrentDownloads = max(1, maxConcurrentDownloads)
         guard cache != nil || destination != nil else {
@@ -1365,11 +1461,17 @@ public extension HubClient {
             if let progressHandler {
                 await progressHandler(progress)
             }
-            return try copySnapshotToLocalDirectoryIfNeeded(
+            let resolved = try copySnapshotToLocalDirectoryIfNeeded(
                 from: fastPath,
                 destination: effectiveDestination,
                 returnCachePath: returnCachePath
             )
+            if let fileProgressHandler {
+                await fileProgressHandler(
+                    cachedSnapshotFileProgress(at: resolved, matching: globs)
+                )
+            }
+            return resolved
         }
 
         if localFilesOnly {
@@ -1383,11 +1485,17 @@ public extension HubClient {
             else {
                 throw HubCacheError.cachedPathResolutionFailed(repo.description)
             }
-            return try copySnapshotToLocalDirectoryIfNeeded(
+            let resolved = try copySnapshotToLocalDirectoryIfNeeded(
                 from: cachedPath,
                 destination: effectiveDestination,
                 returnCachePath: returnCachePath
             )
+            if let fileProgressHandler {
+                await fileProgressHandler(
+                    cachedSnapshotFileProgress(at: resolved, matching: globs)
+                )
+            }
+            return resolved
         }
 
         let allEntries: [Git.TreeEntry]
@@ -1400,11 +1508,17 @@ public extension HubClient {
                 revision: revision,
                 matching: globs
             ) {
-                return try copySnapshotToLocalDirectoryIfNeeded(
+                let resolved = try copySnapshotToLocalDirectoryIfNeeded(
                     from: cachedPath,
                     destination: effectiveDestination,
                     returnCachePath: returnCachePath
                 )
+                if let fileProgressHandler {
+                    await fileProgressHandler(
+                        cachedSnapshotFileProgress(at: resolved, matching: globs)
+                    )
+                }
+                return resolved
             }
             throw error
         }
@@ -1458,9 +1572,17 @@ public extension HubClient {
             }
         let xetEntries = workItems.filter { $0.transport != .lfs }
 
+        // Per-file rows (path + child Progress) for the optional per-file
+        // handler; sampled by the same 100 ms task as the aggregate.
+        let fileRows: [(path: String, size: Int64?, progress: SnapshotProgressBox)] =
+            fileProgressHandler == nil
+            ? []
+            : workItems.map { ($0.entry.path, $0.entry.size.map(Int64.init), $0.progress) }
         let samplingTask = makeSnapshotProgressSamplingTask(
             progress: progress,
-            progressHandler: progressHandler
+            progressHandler: progressHandler,
+            fileRows: fileRows,
+            fileProgressHandler: fileProgressHandler
         )
 
         do {
@@ -1496,6 +1618,13 @@ public extension HubClient {
 
         if let progressHandler {
             await progressHandler(progress)
+        }
+        // Emitted after the sampler is cancelled, for the same reason the
+        // aggregate handler is: the last 100 ms sample can land before the
+        // final bytes, so without this a caller never observes the terminal
+        // per-file state and a fast download leaves rows short of complete.
+        if let fileProgressHandler {
+            await fileProgressHandler(snapshotFileProgress(fileRows))
         }
 
         guard let cache else {
@@ -1576,15 +1705,26 @@ private extension HubClient {
 
     func makeSnapshotProgressSamplingTask(
         progress: Progress,
-        progressHandler: (@MainActor @Sendable (Progress) -> Void)?
+        progressHandler: (@MainActor @Sendable (Progress) -> Void)?,
+        fileRows: [(path: String, size: Int64?, progress: SnapshotProgressBox)],
+        fileProgressHandler: (@MainActor @Sendable ([SnapshotFileProgress]) -> Void)?
     ) -> Task<Void, Never>? {
-        guard let progressHandler else {
+        guard progressHandler != nil || fileProgressHandler != nil else {
             return nil
         }
         let boxedProgress = SnapshotProgressBox(progress)
         return Task(priority: Task.currentPriority) {
             while !Task.isCancelled {
-                await progressHandler(boxedProgress.value)
+                // Sampled before the aggregate handler is awaited: the two
+                // describe the same tick, so a slow aggregate handler must not
+                // age the file rows it is delivered beside.
+                let files = fileProgressHandler == nil ? [] : snapshotFileProgress(fileRows)
+                if let progressHandler {
+                    await progressHandler(boxedProgress.value)
+                }
+                if let fileProgressHandler {
+                    await fileProgressHandler(files)
+                }
                 try? await Task.sleep(for: .milliseconds(100))
             }
         }

--- a/Tests/HuggingFaceTests/HubTests/FileOperationsTests.swift
+++ b/Tests/HuggingFaceTests/HubTests/FileOperationsTests.swift
@@ -120,6 +120,23 @@ import Testing
         }
     }
 
+    private final class PerFileProgressRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _emissions: [[SnapshotFileProgress]] = []
+
+        func record(files: [SnapshotFileProgress]) {
+            lock.lock()
+            _emissions.append(files)
+            lock.unlock()
+        }
+
+        var emissions: [[SnapshotFileProgress]] {
+            lock.lock()
+            defer { lock.unlock() }
+            return _emissions
+        }
+    }
+
     private final class ProgressUnitRecorder: @unchecked Sendable {
         private let lock = NSLock()
         private var _totals: [Int64] = []
@@ -1650,6 +1667,147 @@ import Testing
             #expect(progressRecorder.totals.contains(1000))
             #expect(progressRecorder.lastTotal == 1000)
             #expect(progressRecorder.lastCompleted == 1000)
+        }
+
+        /// Serves two files, holding the first response long enough that the
+        /// 100 ms sampler is guaranteed to publish at least one mid-flight
+        /// emission before the terminal one.
+        private func perFileProgressHandler(
+            commit: String,
+            holdFirstRequestFor delay: TimeInterval
+        ) -> @Sendable (URLRequest) throws -> (HTTPURLResponse, Data) {
+            let listResponse = """
+                [
+                    {"path": "large.bin", "type": "file", "oid": "a", "size": 900},
+                    {"path": "small.bin", "type": "file", "oid": "b", "size": 100}
+                ]
+                """
+            let held = NSLock()
+            nonisolated(unsafe) var alreadyHeld = false
+            return { request in
+                let path = request.url?.path ?? ""
+                if path.contains("/api/models/user/model/tree/") {
+                    let response = HTTPURLResponse(
+                        url: request.url!,
+                        statusCode: 200,
+                        httpVersion: "HTTP/1.1",
+                        headerFields: ["Content-Type": "application/json"]
+                    )!
+                    return (response, Data(listResponse.utf8))
+                }
+
+                guard path.hasPrefix("/user/model/resolve/") else {
+                    let response = HTTPURLResponse(
+                        url: request.url!,
+                        statusCode: 404,
+                        httpVersion: "HTTP/1.1",
+                        headerFields: [:]
+                    )!
+                    return (response, Data())
+                }
+
+                let filename = String(path.split(separator: "/").dropFirst(4).joined(separator: "/"))
+                if request.httpMethod == "HEAD" {
+                    let response = HTTPURLResponse(
+                        url: request.url!,
+                        statusCode: 200,
+                        httpVersion: "HTTP/1.1",
+                        headerFields: ["ETag": "\"etag-\(filename)\"", "X-Repo-Commit": commit]
+                    )!
+                    return (response, Data())
+                }
+
+                if delay > 0 {
+                    held.lock()
+                    let shouldHold = !alreadyHeld
+                    alreadyHeld = true
+                    held.unlock()
+                    if shouldHold { Thread.sleep(forTimeInterval: delay) }
+                }
+
+                let bodySize = filename == "small.bin" ? 100 : 900
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 200,
+                    httpVersion: "HTTP/1.1",
+                    headerFields: ["Content-Type": "application/octet-stream"]
+                )!
+                return (response, Data(repeating: 0x3, count: bodySize))
+            }
+        }
+
+        @Test("downloadSnapshot reports per-file progress", .mockURLSession)
+        func testDownloadSnapshotReportsPerFileProgress() async throws {
+            let commit = "1234567890123456789012345678901234567890"
+            await MockURLProtocol.setHandler(
+                perFileProgressHandler(commit: commit, holdFirstRequestFor: 0.25)
+            )
+
+            let recorder = PerFileProgressRecorder()
+            let (client, cacheDirectory) = createMockClientWithCache()
+            defer { try? FileManager.default.removeItem(at: cacheDirectory) }
+            _ = try await client.downloadSnapshot(
+                of: "user/model",
+                kind: .model,
+                revision: "main",
+                fileProgressHandler: { files in
+                    recorder.record(files: files)
+                }
+            )
+
+            let emissions = recorder.emissions
+            // The sampler must contribute: a terminal emission alone cannot
+            // produce more than one.
+            #expect(emissions.count >= 2)
+
+            let mid = try #require(emissions.first)
+            #expect(mid.count == 2)
+            #expect(mid.allSatisfy { $0.fractionCompleted < 1.0 })
+
+            let last = try #require(emissions.last)
+            #expect(last.count == 2)
+            #expect(last.allSatisfy { $0.fractionCompleted == 1.0 })
+            // Sizes come from the tree listing, so they are stable across every
+            // emission rather than tracking transferred bytes.
+            #expect(last.first { $0.path == "large.bin" }?.sizeBytes == 900)
+            #expect(last.first { $0.path == "small.bin" }?.sizeBytes == 100)
+            #expect(mid.first { $0.path == "large.bin" }?.sizeBytes == 900)
+        }
+
+        @Test("downloadSnapshot reports per-file progress from cache", .mockURLSession)
+        func testDownloadSnapshotReportsPerFileProgressFromCache() async throws {
+            let commit = "1234567890123456789012345678901234567890"
+            await MockURLProtocol.setHandler(
+                perFileProgressHandler(commit: commit, holdFirstRequestFor: 0)
+            )
+
+            let (client, cacheDirectory) = createMockClientWithCache()
+            defer { try? FileManager.default.removeItem(at: cacheDirectory) }
+            // Seed the cache under the commit hash itself. Snapshot metadata is
+            // only written when the revision IS a commit hash, and the fast path
+            // refuses to look without it, so a "main" seed is never reused.
+            _ = try await client.downloadSnapshot(of: "user/model", kind: .model, revision: commit)
+
+            // Second call is served entirely from cache: nothing downloads, so
+            // the sampler never runs and the caller would otherwise see no rows
+            // at all while the aggregate handler reports 100%.
+            let recorder = PerFileProgressRecorder()
+            _ = try await client.downloadSnapshot(
+                of: "user/model",
+                kind: .model,
+                revision: commit,
+                fileProgressHandler: { files in
+                    recorder.record(files: files)
+                }
+            )
+
+            let emissions = recorder.emissions
+            #expect(emissions.count == 1)
+            let rows = try #require(emissions.first)
+            #expect(Set(rows.map(\.path)) == ["large.bin", "small.bin"])
+            #expect(rows.allSatisfy { $0.fractionCompleted == 1.0 })
+            #expect(rows.first { $0.path == "large.bin" }?.sizeBytes == 900)
+            #expect(rows.first { $0.path == "small.bin" }?.sizeBytes == 100)
         }
 
         @Test("downloadSnapshot copies to destination when provided", .mockURLSession)


### PR DESCRIPTION
> **Disclosure:** written with Claude, using Codex in the review and design, then reviewed and validated by a human.

### Summary

Adds an optional `fileProgressHandler` to `downloadSnapshot` so a caller can render one progress row per file instead of a single aggregate bar.

This is the remaining half of #48. #50 (thank you — shipped in 0.10.0) fixed the aggregate progress bug, and the issue title is still the original ask: *"downloadSnapshot(...) Does not report per file progress"*. For a client pulling a multi-shard model repo, an aggregate bar can't say *which* shard is moving or how far along it is — the UI most people want here is one line per file.

The downloader already tracks a child `Progress` per file to weight the aggregate. This exposes it; no new bookkeeping.

### API

```swift
public func downloadSnapshot(
    of repo: Repo.ID,
    // ...
    progressHandler: (@MainActor @Sendable (Progress) -> Void)? = nil,
    fileProgressHandler: (@MainActor @Sendable ([SnapshotFileProgress]) -> Void)? = nil  // new
) async throws -> URL
```

```swift
public struct SnapshotFileProgress: Sendable {
    public let path: String              // repo-relative
    public let sizeBytes: Int64?         // from the tree listing; nil when undeclared
    public let fractionCompleted: Double // 0.0...1.0
}
```

Purely additive: the parameter is trailing with a `nil` default, so existing call sites compile and behave identically, and SE-0286 forward-scan still binds a trailing closure to `progressHandler`. When the handler is nil, no per-file state is built at all.

**Why fraction + declared size rather than byte counters.** Each file's `Progress` is created as `Progress(totalUnitCount: weight, parent:, pendingUnitCount: weight)`, so the aggregate consumes only its *fraction*. The raw counters are an internal representation, not a byte contract: `snapshotWeight` substitutes a sentinel `1` when the tree declares no size, the delegate revises `totalUnitCount` mid-flight only when the server sends a length, and `downloadFileWithXet` deliberately collapses the child to `100/100` on completion. Publishing those counters as "bytes" would be wrong on every one of those paths, and reading the pair non-atomically can show `completed > total`. So this publishes `fractionCompleted` (a single locked read) plus `sizeBytes` taken from the tree listing, which is a real byte figure and stable for the whole download. No change to any transport is required.

### Behavior

- Sampled by the **existing** 100 ms task that already drives `progressHandler` — no second timer, no per-chunk callbacks (which swift-xet#11 found too expensive). Rows are built *before* the aggregate handler is awaited, so a slow aggregate handler can't age them.
- One **terminal emission** after the sampling task is cancelled, mirroring the existing terminal `progressHandler(progress)` call. Without it, a download finishing inside one sampling interval never reports a completed state.
- The three **cache-served paths** (commit fast path, `localFilesOnly`, listFiles-failure fallback) emit one complete set of rows synthesized from the resolved snapshot directory. Previously the fast path emitted an aggregate `1/1` and nothing per-file, so a caller rendering rows saw an empty table on a warm cache.
- A download that **throws or is cancelled** emits no terminal set, matching `progressHandler`. Documented on the type.

### Tests

Two tests in `FileOperationsTests.swift`:
- `downloadSnapshot reports per-file progress` — two files (900 B / 100 B), first response held past one sampling interval so a mid-flight emission is guaranteed. Asserts ≥2 emissions, the first with every row incomplete, the last with every row at 1.0, and `sizeBytes` matching the tree listing in both.
- `downloadSnapshot reports per-file progress from cache` — seeds the cache under the commit hash, then re-requests it; asserts exactly one emission, both rows complete, sizes intact.

Each was mutation-checked: deleting the sampler emission, the terminal emission, the cache-path emission, or the tree-declared size each makes a test fail.

### What this does not do

Large files that go through Xet still report nothing until completion, as noted in #48 — that needs the swift-xet side and stays tracked in #61. This makes per-file state *observable*; it doesn't change how often a transport revises it. `fractionCompleted` is honest about that: a Xet file simply reads 0.0 until it reads 1.0.

### Test plan

- [x] `swift test` — 361 tests, 0 failures
- [x] `swift test --traits Xet` — 367 tests, 0 failures (matching the CI matrix)
- [x] `swift-format lint` clean on both changed files
- [x] Diff is purely additive to the test file — no pre-existing test modified
- [x] Exercised in a real client pulling multi-GB multi-shard model repos